### PR TITLE
Fix foveated DLSS-NR output handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,7 @@ add_executable(
     "${CMAKE_CURRENT_SOURCE_DIR}/src/d3d12_ngx_dispatch.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/d3d12_output_contract.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/diagnostics.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/dlss_nr_contract.cpp"
 )
 target_compile_features(CheekyTests PRIVATE cxx_std_20)
 target_include_directories(

--- a/CheekyTests.vcxproj
+++ b/CheekyTests.vcxproj
@@ -43,6 +43,7 @@
     <ClCompile Include="src\d3d12_ngx_dispatch.cpp" />
     <ClCompile Include="src\d3d12_output_contract.cpp" />
     <ClCompile Include="src\diagnostics.cpp" />
+    <ClCompile Include="src\dlss_nr_contract.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="shared\cheeky_gaze_abi.h" />
@@ -52,6 +53,7 @@
     <ClInclude Include="src\d3d12_ngx_dispatch.hpp" />
     <ClInclude Include="src\d3d12_output_contract.hpp" />
     <ClInclude Include="src\diagnostics.hpp" />
+    <ClInclude Include="src\dlss_nr_contract.hpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/src/d3d12_output_contract.cpp
+++ b/src/d3d12_output_contract.cpp
@@ -2,6 +2,16 @@
 
 namespace cheeky::foveated_dlss {
 
+bool is_dlss_nr_output_compatible(
+    const D3D12_RESOURCE_DESC& game_output
+) noexcept {
+    return game_output.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE2D &&
+        game_output.MipLevels != 0U &&
+        game_output.DepthOrArraySize == 1U &&
+        game_output.SampleDesc.Count == 1U &&
+        (game_output.Flags & D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS) != 0U;
+}
+
 D3D12OutputPlan plan_d3d12_output(
     const D3D12_RESOURCE_DESC& game_output,
     const std::uint32_t private_width,

--- a/src/d3d12_output_contract.hpp
+++ b/src/d3d12_output_contract.hpp
@@ -11,6 +11,10 @@ struct D3D12OutputPlan {
     D3D12_RESOURCE_DESC private_description{};
 };
 
+[[nodiscard]] bool is_dlss_nr_output_compatible(
+    const D3D12_RESOURCE_DESC& game_output
+) noexcept;
+
 [[nodiscard]] D3D12OutputPlan plan_d3d12_output(
     const D3D12_RESOURCE_DESC& game_output,
     std::uint32_t private_width,

--- a/src/dlss_nr.cpp
+++ b/src/dlss_nr.cpp
@@ -1,5 +1,7 @@
 #include "dlss_nr.hpp"
 
+#include "d3d12_output_contract.hpp"
+#include "dlss_nr_contract.hpp"
 #include "runtime.hpp"
 
 #include <Windows.h>
@@ -612,10 +614,7 @@ NgxResult neural_scaling_ratio_callback(NgxParameters* const parameters) noexcep
     auto result = command_list->GetDevice(IID_PPV_ARGS(&device));
     if (FAILED(result) || device == nullptr) return fail("GetDevice", result);
     const auto game_desc = game_output->GetDesc();
-    if (game_desc.Dimension != D3D12_RESOURCE_DIMENSION_TEXTURE2D ||
-        game_desc.MipLevels != 1U || game_desc.DepthOrArraySize != 1U ||
-        game_desc.SampleDesc.Count != 1U ||
-        (game_desc.Flags & D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS) == 0U) {
+    if (!is_dlss_nr_output_compatible(game_desc)) {
         return fail("unsupported output", E_INVALIDARG);
     }
 
@@ -1058,24 +1057,17 @@ void DecodeMain(uint3 dispatch_id : SV_DispatchThreadID) {
 [[nodiscard]] NrRegion calculate_region(
     const Settings& settings,
     const std::uint32_t width,
-    const std::uint32_t height
+    const std::uint32_t height,
+    const FoveationGeometry* const shared_sr_crop,
+    const std::uint32_t render_width,
+    const std::uint32_t render_height
 ) noexcept {
     if (!settings.nr_foveated) {
         return {0U, 0U, width, height, 1.0F, 1.0F, 0.0F, 0.0F};
     }
-    FoveationParameters parameters{};
-    if (settings.nr_use_sr_foveation) {
-        parameters = foveation_parameters(settings);
-    } else {
-        parameters = {
-            settings.nr_width,
-            settings.nr_height,
-            settings.nr_x_offset,
-            settings.nr_height_offset,
-            settings.nr_roundness,
-            settings.nr_transition_width,
-        };
-    }
+    const auto parameters = dlss_nr_foveation_parameters(
+        settings, shared_sr_crop, render_width, render_height
+    );
     FoveationGeometry geometry{};
     if (!calculate_foveation_geometry(
             parameters,
@@ -1296,7 +1288,9 @@ bool calculate_dlss_nr_geometry(
     DlssNrGeometry& geometry
 ) noexcept {
     if (output_width == 0U || output_height == 0U) return false;
-    const auto region = calculate_region(settings, output_width, output_height);
+    const auto region = calculate_region(
+        settings, output_width, output_height, nullptr, 0U, 0U
+    );
     if (region.width == 0U || region.height == 0U) return false;
     geometry = {
         region.base_x,
@@ -1344,17 +1338,26 @@ bool evaluate_dlss_nr(
     device->Release();
     if (!runtime_ready) return false;
 
-    const auto region = calculate_region(settings, frame.output_width, frame.output_height);
+    const auto region = calculate_region(
+        settings,
+        frame.output_width,
+        frame.output_height,
+        frame.has_shared_sr_crop ? &frame.shared_sr_crop : nullptr,
+        frame.input_width,
+        frame.input_height
+    );
     const auto working_width = scaled_extent(region.width, settings.nr_working_scale);
     const auto working_height = scaled_extent(region.height, settings.nr_working_scale);
     NrRegion codec_region = region;
-    if (frame.color_is_region) {
-        codec_region.base_x = 0U;
-        codec_region.base_y = 0U;
-    } else {
-        codec_region.base_x += frame.color_base_x;
-        codec_region.base_y += frame.color_base_y;
-    }
+    const auto resource_base = dlss_nr_resource_base(
+        region.base_x,
+        region.base_y,
+        frame.color_base_x,
+        frame.color_base_y,
+        frame.color_is_region
+    );
+    codec_region.base_x = resource_base.x;
+    codec_region.base_y = resource_base.y;
     const auto color_desc = frame.color->GetDesc();
     if (codec_region.base_x + codec_region.width > color_desc.Width ||
         codec_region.base_y + codec_region.height > color_desc.Height) {
@@ -1437,7 +1440,7 @@ bool evaluate_dlss_nr(
         0U,
         4U,
         settings,
-        region
+        codec_region
     );
     uav_barrier(frame.command_list, gpu->original_output);
     uav_barrier(frame.command_list, gpu->color_proxy);
@@ -1573,7 +1576,7 @@ bool evaluate_dlss_nr(
         1U,
         6U,
         settings,
-        region
+        codec_region
     );
     uav_barrier(frame.command_list, frame.color);
     transition(

--- a/src/dlss_nr.hpp
+++ b/src/dlss_nr.hpp
@@ -54,6 +54,8 @@ struct DlssNrFrame {
     std::uint32_t color_base_x{};
     std::uint32_t color_base_y{};
     bool color_is_region{};
+    FoveationGeometry shared_sr_crop{};
+    bool has_shared_sr_crop{};
 };
 
 struct DlssNrGeometry {

--- a/src/dlss_nr_contract.cpp
+++ b/src/dlss_nr_contract.cpp
@@ -1,0 +1,55 @@
+#include "dlss_nr_contract.hpp"
+
+namespace cheeky::foveated_dlss {
+
+DlssNrResourceBase dlss_nr_resource_base(
+    const std::uint32_t local_x,
+    const std::uint32_t local_y,
+    const std::uint32_t color_base_x,
+    const std::uint32_t color_base_y,
+    const bool color_is_region
+) noexcept {
+    return color_is_region
+        ? DlssNrResourceBase{local_x, local_y}
+        : DlssNrResourceBase{
+            color_base_x + local_x,
+            color_base_y + local_y,
+        };
+}
+
+FoveationParameters dlss_nr_foveation_parameters(
+    const Settings& settings,
+    const FoveationGeometry* const shared_sr_crop,
+    const std::uint32_t render_width,
+    const std::uint32_t render_height
+) noexcept {
+    if (settings.nr_use_sr_foveation) {
+        FoveationParameters parameters{
+            settings.width,
+            settings.height,
+            settings.x_offset,
+            settings.height_offset,
+            settings.roundness,
+            settings.transition_width,
+        };
+        if (shared_sr_crop != nullptr && render_width != 0U &&
+            render_height != 0U) {
+            const auto offsets = foveation_offsets_from_geometry(
+                *shared_sr_crop, render_width, render_height
+            );
+            parameters.x_offset = offsets.x;
+            parameters.y_offset = offsets.y;
+        }
+        return parameters;
+    }
+    return {
+        settings.nr_width,
+        settings.nr_height,
+        settings.nr_x_offset,
+        settings.nr_height_offset,
+        settings.nr_roundness,
+        settings.nr_transition_width,
+    };
+}
+
+}  // namespace cheeky::foveated_dlss

--- a/src/dlss_nr_contract.hpp
+++ b/src/dlss_nr_contract.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "settings.hpp"
+
+#include <cstdint>
+
+namespace cheeky::foveated_dlss {
+
+struct DlssNrResourceBase {
+    std::uint32_t x{};
+    std::uint32_t y{};
+};
+
+[[nodiscard]] DlssNrResourceBase dlss_nr_resource_base(
+    std::uint32_t local_x,
+    std::uint32_t local_y,
+    std::uint32_t color_base_x,
+    std::uint32_t color_base_y,
+    bool color_is_region
+) noexcept;
+
+[[nodiscard]] FoveationParameters dlss_nr_foveation_parameters(
+    const Settings& settings,
+    const FoveationGeometry* shared_sr_crop,
+    std::uint32_t render_width,
+    std::uint32_t render_height
+) noexcept;
+
+}  // namespace cheeky::foveated_dlss

--- a/src/hooks.cpp
+++ b/src/hooks.cpp
@@ -3761,7 +3761,8 @@ void evaluate_nr_after_native_d3d12(
     const NgxHandle* const handle,
     const NgxParameters* const parameters,
     const Settings& settings,
-    const NgxResult result
+    const NgxResult result,
+    const CropGeometry* const shared_sr_crop = nullptr
 ) noexcept {
     if (!settings.nr_enabled || !ngx_succeeded(result) ||
         command_list == nullptr || handle == nullptr || parameters == nullptr ||
@@ -3779,7 +3780,7 @@ void evaluate_nr_after_native_d3d12(
     const auto view_id = static_cast<DlssViewId>(
         reinterpret_cast<std::uintptr_t>(handle)
     );
-    const DlssNrFrame frame{
+    DlssNrFrame frame{
         view_id,
         DlssNrRoute::d3d12_native,
         command_list,
@@ -3808,6 +3809,10 @@ void evaluate_nr_after_native_d3d12(
         get_ui(parameters, "DLSS.Output.Subrect.Base.Y"),
         false,
     };
+    if (shared_sr_crop != nullptr) {
+        frame.shared_sr_crop = *shared_sr_crop;
+        frame.has_shared_sr_crop = true;
+    }
     const auto view_settings = settings_for_view(settings, view_id);
     D3D12NrTimingScope timing{command_list, view_settings.nr_foveated};
     const bool evaluated = evaluate_dlss_nr(
@@ -4042,7 +4047,7 @@ void evaluate_nr_after_native_d3d12(
     }
     if (!ngx_succeeded(result)) return false;
     evaluate_nr_after_native_d3d12(
-        command_list, handle, parameters, effective_settings, result
+        command_list, handle, parameters, settings, result, &crop
     );
     diagnostic_note_activation(DiagnosticApi::d3d12, crop);
     return true;

--- a/tests/gaze_tests.cpp
+++ b/tests/gaze_tests.cpp
@@ -2,6 +2,7 @@
 #include "d3d12_ngx_dispatch.hpp"
 #include "d3d12_output_contract.hpp"
 #include "diagnostics.hpp"
+#include "dlss_nr_contract.hpp"
 #include "foveation.hpp"
 #include "gaze_math.hpp"
 #include "gaze_policy.hpp"
@@ -527,6 +528,60 @@ void test_multimip_game_output_uses_single_mip_private_output() {
         "private D3D12 output preserves the game output format");
 }
 
+void test_multimip_game_output_is_dlss_nr_compatible() {
+    using namespace cheeky::foveated_dlss;
+    D3D12_RESOURCE_DESC game_output{};
+    game_output.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+    game_output.Width = 10380U;
+    game_output.Height = 4168U;
+    game_output.DepthOrArraySize = 1U;
+    game_output.MipLevels = 4U;
+    game_output.Format = DXGI_FORMAT_R11G11B10_FLOAT;
+    game_output.SampleDesc.Count = 1U;
+    game_output.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
+
+    expect(is_dlss_nr_output_compatible(game_output),
+        "DLSS-NR accepts the multi-mip mip-zero output used by ACE");
+}
+
+void test_dlss_nr_maps_right_eye_region_into_packed_output() {
+    using namespace cheeky::foveated_dlss;
+    const auto base = dlss_nr_resource_base(
+        2544U, 928U, 5190U, 0U, false
+    );
+    expect(base.x == 7734U && base.y == 928U,
+        "right-eye DLSS-NR region includes the packed output base");
+    const auto isolated = dlss_nr_resource_base(
+        2544U, 928U, 5190U, 0U, true
+    );
+    expect(isolated.x == 2544U && isolated.y == 928U,
+        "isolated DLSS-NR region remains resource-local");
+}
+
+void test_dlss_nr_reuses_live_sr_crop_center() {
+    using namespace cheeky::foveated_dlss;
+    Settings settings{};
+    settings.nr_use_sr_foveation = true;
+    settings.width = 0.5F;
+    settings.height = 0.5F;
+    settings.x_offset = -0.8F;
+    settings.height_offset = -0.8F;
+    const FoveationGeometry live_sr_crop{
+        1000U, 600U, 1000U, 800U,
+        2000U, 1200U, 2000U, 1600U,
+    };
+    const auto expected = foveation_offsets_from_geometry(
+        live_sr_crop, 3000U, 2000U
+    );
+    const auto parameters = dlss_nr_foveation_parameters(
+        settings, &live_sr_crop, 3000U, 2000U
+    );
+    expect_near(parameters.x_offset, expected.x, 0.0001F,
+        "DLSS-NR follows the live SR horizontal center");
+    expect_near(parameters.y_offset, expected.y, 0.0001F,
+        "DLSS-NR follows the live SR vertical center");
+}
+
 }  // namespace
 
 int main() {
@@ -545,6 +600,9 @@ int main() {
     test_nested_d3d12_lifecycle_scope_is_passthrough();
     test_core_d3d12_route_is_published_to_diagnostics();
     test_multimip_game_output_uses_single_mip_private_output();
+    test_multimip_game_output_is_dlss_nr_compatible();
+    test_dlss_nr_maps_right_eye_region_into_packed_output();
+    test_dlss_nr_reuses_live_sr_crop_center();
     if (failures != 0) {
         std::cerr << failures << " test(s) failed\n";
         return 1;


### PR DESCRIPTION
Fixes #7.

## Summary

- accept multi-mip D3D12 outputs while retaining the single-sample and UAV requirements
- apply packed-stereo resource origins to DLSS-NR codec dispatches for the correct eye
- reuse the live DLSS-SR gaze crop when DLSS-NR follows SR foveation settings
- add regression coverage for all three cases

## Testing

- `scripts/build.ps1 -Configuration Release`
- Assetto Corsa EVO / Pimax OpenXR hardware test: both eye borders followed gaze
- latest hardware trace: 34 sampled DLSS-NR activations and zero failures


## Merge order

All three PRs target `ClarkCheekyKent/CheekyFoveatedDLSS:master`. Merge in this order:
1. [Upstream PR #3](https://github.com/ClarkCheekyKent/CheekyFoveatedDLSS/pull/3) — replaces fork PR #2: DLSS-NR output handling.
2. [Upstream PR #4](https://github.com/ClarkCheekyKent/CheekyFoveatedDLSS/pull/4) — replaces fork PR #3: peripheral DLAA scale hot reload.
3. [Upstream PR #5](https://github.com/ClarkCheekyKent/CheekyFoveatedDLSS/pull/5) — replaces fork PR #5: retain the OpenXR layer for the cached gaze export.

The source branches contain earlier changes in the sequence, so later PR diffs include those changes until they are merged upstream.

This PR is first in the sequence.

Replaces https://github.com/Williem3/CheekyFoveatedDLSS/pull/2. Hardware validation above is carried over from the original PR. The rebased branch passed a fresh Release build and the automated Cheeky tests; hardware validation has not been repeated.



## Rebase validation

Rebased onto upstream master at 360cb94, preserving merge order #3, then #4, then #5. Earlier eye-tracking prerequisite commits are already upstream and are no longer included in the PR stack. Release build and automated Cheeky tests passed on each of the three rebased branches.

