### PR TITLE
Fix peripheral DLAA scale hot reload

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,7 @@ add_executable(
     "${CMAKE_CURRENT_SOURCE_DIR}/src/d3d12_ngx_dispatch.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/d3d12_output_contract.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/diagnostics.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/dlss_nr_contract.cpp"
 )
 target_compile_features(CheekyTests PRIVATE cxx_std_20)
 target_include_directories(

--- a/CheekyTests.vcxproj
+++ b/CheekyTests.vcxproj
@@ -43,6 +43,7 @@
     <ClCompile Include="src\d3d12_ngx_dispatch.cpp" />
     <ClCompile Include="src\d3d12_output_contract.cpp" />
     <ClCompile Include="src\diagnostics.cpp" />
+    <ClCompile Include="src\dlss_nr_contract.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="shared\cheeky_gaze_abi.h" />
@@ -52,6 +53,7 @@
     <ClInclude Include="src\d3d12_ngx_dispatch.hpp" />
     <ClInclude Include="src\d3d12_output_contract.hpp" />
     <ClInclude Include="src\diagnostics.hpp" />
+    <ClInclude Include="src\dlss_nr_contract.hpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/CheekyTests.vcxproj
+++ b/CheekyTests.vcxproj
@@ -54,6 +54,7 @@
     <ClInclude Include="src\d3d12_output_contract.hpp" />
     <ClInclude Include="src\diagnostics.hpp" />
     <ClInclude Include="src\dlss_nr_contract.hpp" />
+    <ClInclude Include="src\peripheral_dlaa_generation.hpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/src/d3d12_output_contract.cpp
+++ b/src/d3d12_output_contract.cpp
@@ -2,6 +2,16 @@
 
 namespace cheeky::foveated_dlss {
 
+bool is_dlss_nr_output_compatible(
+    const D3D12_RESOURCE_DESC& game_output
+) noexcept {
+    return game_output.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE2D &&
+        game_output.MipLevels != 0U &&
+        game_output.DepthOrArraySize == 1U &&
+        game_output.SampleDesc.Count == 1U &&
+        (game_output.Flags & D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS) != 0U;
+}
+
 D3D12OutputPlan plan_d3d12_output(
     const D3D12_RESOURCE_DESC& game_output,
     const std::uint32_t private_width,

--- a/src/d3d12_output_contract.hpp
+++ b/src/d3d12_output_contract.hpp
@@ -11,6 +11,10 @@ struct D3D12OutputPlan {
     D3D12_RESOURCE_DESC private_description{};
 };
 
+[[nodiscard]] bool is_dlss_nr_output_compatible(
+    const D3D12_RESOURCE_DESC& game_output
+) noexcept;
+
 [[nodiscard]] D3D12OutputPlan plan_d3d12_output(
     const D3D12_RESOURCE_DESC& game_output,
     std::uint32_t private_width,

--- a/src/dlss_nr.cpp
+++ b/src/dlss_nr.cpp
@@ -1,5 +1,7 @@
 #include "dlss_nr.hpp"
 
+#include "d3d12_output_contract.hpp"
+#include "dlss_nr_contract.hpp"
 #include "runtime.hpp"
 
 #include <Windows.h>
@@ -612,10 +614,7 @@ NgxResult neural_scaling_ratio_callback(NgxParameters* const parameters) noexcep
     auto result = command_list->GetDevice(IID_PPV_ARGS(&device));
     if (FAILED(result) || device == nullptr) return fail("GetDevice", result);
     const auto game_desc = game_output->GetDesc();
-    if (game_desc.Dimension != D3D12_RESOURCE_DIMENSION_TEXTURE2D ||
-        game_desc.MipLevels != 1U || game_desc.DepthOrArraySize != 1U ||
-        game_desc.SampleDesc.Count != 1U ||
-        (game_desc.Flags & D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS) == 0U) {
+    if (!is_dlss_nr_output_compatible(game_desc)) {
         return fail("unsupported output", E_INVALIDARG);
     }
 
@@ -1058,24 +1057,17 @@ void DecodeMain(uint3 dispatch_id : SV_DispatchThreadID) {
 [[nodiscard]] NrRegion calculate_region(
     const Settings& settings,
     const std::uint32_t width,
-    const std::uint32_t height
+    const std::uint32_t height,
+    const FoveationGeometry* const shared_sr_crop,
+    const std::uint32_t render_width,
+    const std::uint32_t render_height
 ) noexcept {
     if (!settings.nr_foveated) {
         return {0U, 0U, width, height, 1.0F, 1.0F, 0.0F, 0.0F};
     }
-    FoveationParameters parameters{};
-    if (settings.nr_use_sr_foveation) {
-        parameters = foveation_parameters(settings);
-    } else {
-        parameters = {
-            settings.nr_width,
-            settings.nr_height,
-            settings.nr_x_offset,
-            settings.nr_height_offset,
-            settings.nr_roundness,
-            settings.nr_transition_width,
-        };
-    }
+    const auto parameters = dlss_nr_foveation_parameters(
+        settings, shared_sr_crop, render_width, render_height
+    );
     FoveationGeometry geometry{};
     if (!calculate_foveation_geometry(
             parameters,
@@ -1296,7 +1288,9 @@ bool calculate_dlss_nr_geometry(
     DlssNrGeometry& geometry
 ) noexcept {
     if (output_width == 0U || output_height == 0U) return false;
-    const auto region = calculate_region(settings, output_width, output_height);
+    const auto region = calculate_region(
+        settings, output_width, output_height, nullptr, 0U, 0U
+    );
     if (region.width == 0U || region.height == 0U) return false;
     geometry = {
         region.base_x,
@@ -1344,17 +1338,26 @@ bool evaluate_dlss_nr(
     device->Release();
     if (!runtime_ready) return false;
 
-    const auto region = calculate_region(settings, frame.output_width, frame.output_height);
+    const auto region = calculate_region(
+        settings,
+        frame.output_width,
+        frame.output_height,
+        frame.has_shared_sr_crop ? &frame.shared_sr_crop : nullptr,
+        frame.input_width,
+        frame.input_height
+    );
     const auto working_width = scaled_extent(region.width, settings.nr_working_scale);
     const auto working_height = scaled_extent(region.height, settings.nr_working_scale);
     NrRegion codec_region = region;
-    if (frame.color_is_region) {
-        codec_region.base_x = 0U;
-        codec_region.base_y = 0U;
-    } else {
-        codec_region.base_x += frame.color_base_x;
-        codec_region.base_y += frame.color_base_y;
-    }
+    const auto resource_base = dlss_nr_resource_base(
+        region.base_x,
+        region.base_y,
+        frame.color_base_x,
+        frame.color_base_y,
+        frame.color_is_region
+    );
+    codec_region.base_x = resource_base.x;
+    codec_region.base_y = resource_base.y;
     const auto color_desc = frame.color->GetDesc();
     if (codec_region.base_x + codec_region.width > color_desc.Width ||
         codec_region.base_y + codec_region.height > color_desc.Height) {
@@ -1437,7 +1440,7 @@ bool evaluate_dlss_nr(
         0U,
         4U,
         settings,
-        region
+        codec_region
     );
     uav_barrier(frame.command_list, gpu->original_output);
     uav_barrier(frame.command_list, gpu->color_proxy);
@@ -1573,7 +1576,7 @@ bool evaluate_dlss_nr(
         1U,
         6U,
         settings,
-        region
+        codec_region
     );
     uav_barrier(frame.command_list, frame.color);
     transition(

--- a/src/dlss_nr.hpp
+++ b/src/dlss_nr.hpp
@@ -54,6 +54,8 @@ struct DlssNrFrame {
     std::uint32_t color_base_x{};
     std::uint32_t color_base_y{};
     bool color_is_region{};
+    FoveationGeometry shared_sr_crop{};
+    bool has_shared_sr_crop{};
 };
 
 struct DlssNrGeometry {

--- a/src/dlss_nr_contract.cpp
+++ b/src/dlss_nr_contract.cpp
@@ -1,0 +1,55 @@
+#include "dlss_nr_contract.hpp"
+
+namespace cheeky::foveated_dlss {
+
+DlssNrResourceBase dlss_nr_resource_base(
+    const std::uint32_t local_x,
+    const std::uint32_t local_y,
+    const std::uint32_t color_base_x,
+    const std::uint32_t color_base_y,
+    const bool color_is_region
+) noexcept {
+    return color_is_region
+        ? DlssNrResourceBase{local_x, local_y}
+        : DlssNrResourceBase{
+            color_base_x + local_x,
+            color_base_y + local_y,
+        };
+}
+
+FoveationParameters dlss_nr_foveation_parameters(
+    const Settings& settings,
+    const FoveationGeometry* const shared_sr_crop,
+    const std::uint32_t render_width,
+    const std::uint32_t render_height
+) noexcept {
+    if (settings.nr_use_sr_foveation) {
+        FoveationParameters parameters{
+            settings.width,
+            settings.height,
+            settings.x_offset,
+            settings.height_offset,
+            settings.roundness,
+            settings.transition_width,
+        };
+        if (shared_sr_crop != nullptr && render_width != 0U &&
+            render_height != 0U) {
+            const auto offsets = foveation_offsets_from_geometry(
+                *shared_sr_crop, render_width, render_height
+            );
+            parameters.x_offset = offsets.x;
+            parameters.y_offset = offsets.y;
+        }
+        return parameters;
+    }
+    return {
+        settings.nr_width,
+        settings.nr_height,
+        settings.nr_x_offset,
+        settings.nr_height_offset,
+        settings.nr_roundness,
+        settings.nr_transition_width,
+    };
+}
+
+}  // namespace cheeky::foveated_dlss

--- a/src/dlss_nr_contract.hpp
+++ b/src/dlss_nr_contract.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "settings.hpp"
+
+#include <cstdint>
+
+namespace cheeky::foveated_dlss {
+
+struct DlssNrResourceBase {
+    std::uint32_t x{};
+    std::uint32_t y{};
+};
+
+[[nodiscard]] DlssNrResourceBase dlss_nr_resource_base(
+    std::uint32_t local_x,
+    std::uint32_t local_y,
+    std::uint32_t color_base_x,
+    std::uint32_t color_base_y,
+    bool color_is_region
+) noexcept;
+
+[[nodiscard]] FoveationParameters dlss_nr_foveation_parameters(
+    const Settings& settings,
+    const FoveationGeometry* shared_sr_crop,
+    std::uint32_t render_width,
+    std::uint32_t render_height
+) noexcept;
+
+}  // namespace cheeky::foveated_dlss

--- a/src/hooks.cpp
+++ b/src/hooks.cpp
@@ -3761,7 +3761,8 @@ void evaluate_nr_after_native_d3d12(
     const NgxHandle* const handle,
     const NgxParameters* const parameters,
     const Settings& settings,
-    const NgxResult result
+    const NgxResult result,
+    const CropGeometry* const shared_sr_crop = nullptr
 ) noexcept {
     if (!settings.nr_enabled || !ngx_succeeded(result) ||
         command_list == nullptr || handle == nullptr || parameters == nullptr ||
@@ -3779,7 +3780,7 @@ void evaluate_nr_after_native_d3d12(
     const auto view_id = static_cast<DlssViewId>(
         reinterpret_cast<std::uintptr_t>(handle)
     );
-    const DlssNrFrame frame{
+    DlssNrFrame frame{
         view_id,
         DlssNrRoute::d3d12_native,
         command_list,
@@ -3808,6 +3809,10 @@ void evaluate_nr_after_native_d3d12(
         get_ui(parameters, "DLSS.Output.Subrect.Base.Y"),
         false,
     };
+    if (shared_sr_crop != nullptr) {
+        frame.shared_sr_crop = *shared_sr_crop;
+        frame.has_shared_sr_crop = true;
+    }
     const auto view_settings = settings_for_view(settings, view_id);
     D3D12NrTimingScope timing{command_list, view_settings.nr_foveated};
     const bool evaluated = evaluate_dlss_nr(
@@ -4042,7 +4047,7 @@ void evaluate_nr_after_native_d3d12(
     }
     if (!ngx_succeeded(result)) return false;
     evaluate_nr_after_native_d3d12(
-        command_list, handle, parameters, effective_settings, result
+        command_list, handle, parameters, settings, result, &crop
     );
     diagnostic_note_activation(DiagnosticApi::d3d12, crop);
     return true;

--- a/src/hooks.cpp
+++ b/src/hooks.cpp
@@ -1504,6 +1504,7 @@ void note_d3d12_command_list_submission_impl(
     note_peripheral_dlaa_submission(queue, command_list);
     ID3D12CommandList* motion_lists[]{command_list};
     crop_motion12_submitted(queue, 1U, motion_lists);
+    note_peripheral_dlaa_command_list_submission(queue, command_list);
     std::uint64_t frequency{};
     if (FAILED(queue->GetTimestampFrequency(&frequency)) || frequency == 0U) return;
     std::lock_guard lock(d3d12_nr_timing_mutex);

--- a/src/peripheral_dlaa.cpp
+++ b/src/peripheral_dlaa.cpp
@@ -1,10 +1,12 @@
 #include "peripheral_dlaa.hpp"
+#include "peripheral_dlaa_generation.hpp"
 
 #include "runtime.hpp"
 
 #include <d3dcompiler.h>
 
 #include <algorithm>
+#include <array>
 #include <cstdint>
 #include <cstring>
 #include <deque>
@@ -124,6 +126,29 @@ void uav_barrier(
 }
 
 constexpr std::uint32_t converter_descriptor_set_count = 256U;
+constexpr DWORD generation_wait_timeout_ms = 5000U;
+constexpr GUID peripheral_submission_token_guid{
+    0x6a4c69b3U,
+    0x2e17U,
+    0x4f68U,
+    {0xa8U, 0xc1U, 0x94U, 0x0dU, 0x8dU, 0xefU, 0x56U, 0x3bU},
+};
+
+struct PeripheralDeviceSync {
+    ID3D12Device* device{};
+    ID3D12Device* fence_device{};
+    ID3D12Fence* fence{};
+    HANDLE completion_event{};
+    std::deque<ID3D12CommandQueue*> queues;
+    std::uint64_t next_fence_value{};
+    std::uint64_t pending_fence_value{};
+};
+
+struct PendingPeripheralSubmission {
+    std::uint64_t token{};
+    ID3D12GraphicsCommandList* command_list{};
+    PeripheralDeviceSync* device_sync{};
+};
 
 struct PeripheralGpuUse {
     ID3D12GraphicsCommandList* command_list{};
@@ -152,9 +177,13 @@ struct PeripheralViewState {
     DXGI_FORMAT depth_format{DXGI_FORMAT_UNKNOWN};
     DXGI_FORMAT output_format{DXGI_FORMAT_UNKNOWN};
     DXGI_FORMAT motion_format{DXGI_FORMAT_UNKNOWN};
+    std::uint32_t scale_bits{};
+    std::uint32_t create_flags{};
+    std::array<std::uint32_t, 6U> presets{};
     std::uint32_t descriptor_size{};
     std::uint32_t next_descriptor_set{};
     std::deque<PeripheralGpuUse> gpu_uses;
+    bool safe_to_replace{};
 };
 
 std::mutex state_mutex;
@@ -175,6 +204,165 @@ void record_gpu_use(
     }
     command_list->AddRef();
     state.gpu_uses.push_back({command_list});
+}
+
+std::mutex submission_mutex;
+std::deque<PeripheralDeviceSync> device_sync_states;
+std::deque<PendingPeripheralSubmission> pending_submissions;
+std::uint64_t next_submission_token{};
+std::uint64_t generation_rejection_sequence{};
+
+[[nodiscard]] PeripheralDeviceSync* find_device_sync(
+    ID3D12Device* const device
+) noexcept {
+    for (auto& sync : device_sync_states) {
+        if (sync.device == device) return &sync;
+    }
+    return nullptr;
+}
+
+[[nodiscard]] PeripheralDeviceSync* find_or_create_device_sync(
+    ID3D12Device* const device
+) noexcept {
+    if (device == nullptr) return nullptr;
+    if (auto* const existing = find_device_sync(device); existing != nullptr) {
+        return existing;
+    }
+    device_sync_states.push_back({});
+    auto& created = device_sync_states.back();
+    device->AddRef();
+    created.device = device;
+    return &created;
+}
+
+[[nodiscard]] bool note_peripheral_command_list(
+    ID3D12GraphicsCommandList* const command_list,
+    ID3D12Device* const device
+) noexcept {
+    if (command_list == nullptr || device == nullptr) return false;
+    std::lock_guard lock(submission_mutex);
+    auto* const sync = find_or_create_device_sync(device);
+    if (sync == nullptr) return false;
+    for (const auto& pending : pending_submissions) {
+        if (pending.command_list == command_list) return true;
+    }
+    auto token = ++next_submission_token;
+    if (token == 0U) token = ++next_submission_token;
+    if (FAILED(command_list->SetPrivateData(
+            peripheral_submission_token_guid,
+            static_cast<UINT>(sizeof(token)),
+            &token
+        ))) {
+        return false;
+    }
+    command_list->AddRef();
+    pending_submissions.push_back({token, command_list, sync});
+    return true;
+}
+
+[[nodiscard]] bool wait_for_peripheral_fence(
+    PeripheralDeviceSync& sync
+) noexcept {
+    const auto value = sync.pending_fence_value;
+    if (value == 0U || sync.fence == nullptr) return false;
+    const auto completed = sync.fence->GetCompletedValue();
+    if (completed == UINT64_MAX) return false;
+    if (completed >= value) {
+        sync.pending_fence_value = 0U;
+        return true;
+    }
+    if (sync.completion_event == nullptr) {
+        sync.completion_event = CreateEventW(nullptr, FALSE, FALSE, nullptr);
+        if (sync.completion_event == nullptr) return false;
+    }
+    if (!ResetEvent(sync.completion_event)) return false;
+    if (FAILED(sync.fence->SetEventOnCompletion(
+            value,
+            sync.completion_event
+        ))) {
+        return false;
+    }
+    if (WaitForSingleObject(
+            sync.completion_event,
+            generation_wait_timeout_ms
+        ) != WAIT_OBJECT_0) {
+        return false;
+    }
+    const auto completed_after_wait = sync.fence->GetCompletedValue();
+    if (completed_after_wait == UINT64_MAX || completed_after_wait < value) {
+        return false;
+    }
+    sync.pending_fence_value = 0U;
+    return true;
+}
+
+[[nodiscard]] bool synchronize_peripheral_device(
+    ID3D12Device* const device
+) noexcept {
+    if (device == nullptr) return false;
+    // Submission callbacks can precede ExecuteCommandLists. Upstream marks
+    // uses as signaled at present, after the queued work has been submitted.
+    for (const auto& state : states) {
+        if (state.device != device) continue;
+        for (const auto& use : state.gpu_uses) {
+            if (!use.signaled) return false;
+        }
+    }
+    std::lock_guard lock(submission_mutex);
+    auto* const sync = find_device_sync(device);
+    if (sync == nullptr || sync->fence_device == nullptr ||
+        sync->queues.empty()) {
+        return false;
+    }
+    for (const auto& pending : pending_submissions) {
+        if (pending.device_sync == sync) return false;
+    }
+
+    if (sync->pending_fence_value != 0U) {
+        return wait_for_peripheral_fence(*sync);
+    }
+    if (sync->fence == nullptr && FAILED(sync->fence_device->CreateFence(
+            0U,
+            D3D12_FENCE_FLAG_NONE,
+            IID_PPV_ARGS(&sync->fence)
+        ))) {
+        return false;
+    }
+
+    std::uint64_t previous_value{};
+    for (auto* const queue : sync->queues) {
+        const auto value = ++sync->next_fence_value;
+        if (previous_value != 0U && FAILED(queue->Wait(
+                sync->fence,
+                previous_value
+            ))) {
+            return false;
+        }
+        if (FAILED(queue->Signal(sync->fence, value))) return false;
+        previous_value = value;
+    }
+    sync->pending_fence_value = previous_value;
+    return wait_for_peripheral_fence(*sync);
+}
+
+void release_submission_tracking() noexcept {
+    std::lock_guard lock(submission_mutex);
+    for (auto& pending : pending_submissions) {
+        release(pending.command_list);
+    }
+    pending_submissions.clear();
+    for (auto& sync : device_sync_states) {
+        for (auto*& queue : sync.queues) release(queue);
+        sync.queues.clear();
+        release(sync.fence);
+        if (sync.completion_event != nullptr) {
+            CloseHandle(sync.completion_event);
+            sync.completion_event = nullptr;
+        }
+        release(sync.device);
+        release(sync.fence_device);
+    }
+    device_sync_states.clear();
 }
 
 void release_state(PeripheralViewState& state) noexcept {
@@ -396,6 +584,28 @@ void release_state(PeripheralViewState& state) noexcept {
     }
 }
 
+[[nodiscard]] std::array<std::uint32_t, 6U> generation_presets(
+    const PeripheralDlaaRequest& request
+) noexcept {
+    std::array<std::uint32_t, 6U> presets{};
+    presets[0] = request.preset;
+    if (request.parameters == nullptr) return presets;
+    constexpr std::array<const char*, 5U> names{
+        "DLSS.Hint.Render.Preset.Quality",
+        "DLSS.Hint.Render.Preset.Balanced",
+        "DLSS.Hint.Render.Preset.Performance",
+        "DLSS.Hint.Render.Preset.UltraPerformance",
+        "DLSS.Hint.Render.Preset.UltraQuality",
+    };
+    for (std::size_t index{}; index < names.size(); ++index) {
+        presets[index + 1U] = get_ngx_integer_bits(
+            request.parameters,
+            names[index]
+        );
+    }
+    return presets;
+}
+
 [[nodiscard]] PeripheralViewState* find_or_create_state(
     const PeripheralDlaaRequest& request
 ) noexcept {
@@ -426,6 +636,9 @@ void release_state(PeripheralViewState& state) noexcept {
     const auto color_format = typed_resource_format(color_desc.Format);
     const auto depth_format = depth_srv_format(depth_desc.Format);
     const auto motion_format = typed_resource_format(motion_desc.Format);
+    const auto presets = generation_presets(request);
+    std::uint32_t scale_bits{};
+    std::memcpy(&scale_bits, &request.scale, sizeof(scale_bits));
 
     std::lock_guard lock(state_mutex);
     for (auto& state : states) {
@@ -438,16 +651,58 @@ void release_state(PeripheralViewState& state) noexcept {
             state.color_format == color_format &&
             state.depth_format == depth_format &&
             state.output_format == output_desc.Format &&
-            state.motion_format == motion_format;
-        if (compatible) {
+            state.motion_format == motion_format &&
+            state.scale_bits == scale_bits &&
+            state.create_flags == request.create_flags &&
+            state.presets == presets;
+        bool synchronized = compatible || state.safe_to_replace;
+        if (!synchronized && synchronize_peripheral_device(state.device)) {
+            synchronized = true;
+            for (auto& synchronized_state : states) {
+                if (synchronized_state.device == state.device) {
+                    synchronized_state.safe_to_replace = true;
+                }
+            }
+        }
+        const auto decision = peripheral_dlaa_generation_decision(
+            compatible,
+            synchronized
+        );
+        if (decision == PeripheralDlaaGenerationDecision::reuse) {
+            state.safe_to_replace = false;
             device->Release();
             record_gpu_use(state, request.command_list);
             return &state;
         }
+        if (decision == PeripheralDlaaGenerationDecision::reject) {
+            const auto rejection = ++generation_rejection_sequence;
+            if (rejection <= 8U || rejection % 600U == 0U) {
+                trace_event(
+                    "Peripheral DLAA generation change rejected seq=%llu "
+                    "view=%llu: submission queue synchronization unavailable",
+                    static_cast<unsigned long long>(rejection),
+                    static_cast<unsigned long long>(request.view_id)
+                );
+            }
+            device->Release();
+            return nullptr;
+        }
+        trace_event(
+            "Peripheral DLAA generation synchronized view=%llu "
+            "size=%ux%u->%ux%u preset=%u->%u",
+            static_cast<unsigned long long>(request.view_id),
+            state.working_width,
+            state.working_height,
+            dimensions.width,
+            dimensions.height,
+            state.presets[0],
+            request.preset
+        );
         // Recorded command lists do not retain the resources referenced by
         // their descriptors. Keep the old generation until its queues finish.
         retired_states.push_back(std::move(state));
         state = {};
+        release_d3d12_view(peripheral_dlaa_view_id(request.view_id));
         state.view_id = request.view_id;
         state.device = device;
         state.render_width = request.render_width;
@@ -459,6 +714,9 @@ void release_state(PeripheralViewState& state) noexcept {
         state.output_format = output_desc.Format;
         state.motion_format = motion_format;
         record_gpu_use(state, request.command_list);
+        state.scale_bits = scale_bits;
+        state.create_flags = request.create_flags;
+        state.presets = presets;
         return &state;
     }
 
@@ -475,6 +733,9 @@ void release_state(PeripheralViewState& state) noexcept {
     state.output_format = output_desc.Format;
     state.motion_format = motion_format;
     record_gpu_use(state, request.command_list);
+    state.scale_bits = scale_bits;
+    state.create_flags = request.create_flags;
+    state.presets = presets;
     return &state;
 }
 
@@ -802,6 +1063,9 @@ bool prepare_peripheral_dlaa_resources(
     }
     auto* const state = find_or_create_state(request);
     if (state == nullptr || !ensure_output(*state, request)) return false;
+    if (!note_peripheral_command_list(request.command_list, state->device)) {
+        return false;
+    }
 
     resources.working_width = state->working_width;
     resources.working_height = state->working_height;
@@ -1103,6 +1367,52 @@ void restore_peripheral_dlaa_output(
     );
 }
 
+void note_peripheral_dlaa_command_list_submission(
+    ID3D12CommandQueue* const queue,
+    ID3D12GraphicsCommandList* const command_list
+) noexcept {
+    if (queue == nullptr || command_list == nullptr) return;
+    std::uint64_t token{};
+    UINT token_size = static_cast<UINT>(sizeof(token));
+    if (FAILED(command_list->GetPrivateData(
+            peripheral_submission_token_guid,
+            &token_size,
+            &token
+        )) || token_size != static_cast<UINT>(sizeof(token)) || token == 0U) {
+        return;
+    }
+    ID3D12Device* queue_device{};
+    if (FAILED(queue->GetDevice(IID_PPV_ARGS(&queue_device))) ||
+        queue_device == nullptr) {
+        return;
+    }
+
+    std::lock_guard lock(submission_mutex);
+    for (auto iterator = pending_submissions.begin();
+         iterator != pending_submissions.end();) {
+        if (iterator->token != token || iterator->device_sync == nullptr) {
+            ++iterator;
+            continue;
+        }
+        auto& sync = *iterator->device_sync;
+        if (sync.fence_device == nullptr) {
+            sync.fence_device = queue_device;
+            queue_device = nullptr;
+        } else if (sync.fence_device != queue_device) {
+            break;
+        }
+        auto& queues = sync.queues;
+        if (std::find(queues.begin(), queues.end(), queue) == queues.end()) {
+            queue->AddRef();
+            queues.push_back(queue);
+        }
+        release(iterator->command_list);
+        iterator = pending_submissions.erase(iterator);
+        break;
+    }
+    release(queue_device);
+}
+
 void release_peripheral_dlaa_view(const DlssViewId view_id) noexcept {
     {
         std::lock_guard lock(state_mutex);
@@ -1131,6 +1441,7 @@ void release_peripheral_dlaa_resources() noexcept {
     for (const auto view_id : view_ids) {
         release_d3d12_view(peripheral_dlaa_view_id(view_id));
     }
+    release_submission_tracking();
 }
 
 void note_peripheral_dlaa_submission(

--- a/src/peripheral_dlaa.hpp
+++ b/src/peripheral_dlaa.hpp
@@ -107,6 +107,11 @@ void restore_peripheral_dlaa_output(
     const PeripheralDlaaResources& resources
 ) noexcept;
 
+void note_peripheral_dlaa_command_list_submission(
+    ID3D12CommandQueue* queue,
+    ID3D12GraphicsCommandList* command_list
+) noexcept;
+
 void release_peripheral_dlaa_view(DlssViewId view_id) noexcept;
 void release_peripheral_dlaa_resources() noexcept;
 void note_peripheral_dlaa_submission(

--- a/src/peripheral_dlaa_generation.hpp
+++ b/src/peripheral_dlaa_generation.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+namespace cheeky::foveated_dlss {
+
+enum class PeripheralDlaaGenerationDecision {
+    reuse,
+    replace,
+    reject,
+};
+
+[[nodiscard]] constexpr PeripheralDlaaGenerationDecision
+peripheral_dlaa_generation_decision(
+    const bool compatible,
+    const bool synchronization_complete
+) noexcept {
+    if (compatible) return PeripheralDlaaGenerationDecision::reuse;
+    return synchronization_complete
+        ? PeripheralDlaaGenerationDecision::replace
+        : PeripheralDlaaGenerationDecision::reject;
+}
+
+}  // namespace cheeky::foveated_dlss

--- a/tests/gaze_tests.cpp
+++ b/tests/gaze_tests.cpp
@@ -2,6 +2,7 @@
 #include "d3d12_ngx_dispatch.hpp"
 #include "d3d12_output_contract.hpp"
 #include "diagnostics.hpp"
+#include "dlss_nr_contract.hpp"
 #include "foveation.hpp"
 #include "gaze_math.hpp"
 #include "gaze_policy.hpp"
@@ -527,6 +528,60 @@ void test_multimip_game_output_uses_single_mip_private_output() {
         "private D3D12 output preserves the game output format");
 }
 
+void test_multimip_game_output_is_dlss_nr_compatible() {
+    using namespace cheeky::foveated_dlss;
+    D3D12_RESOURCE_DESC game_output{};
+    game_output.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+    game_output.Width = 10380U;
+    game_output.Height = 4168U;
+    game_output.DepthOrArraySize = 1U;
+    game_output.MipLevels = 4U;
+    game_output.Format = DXGI_FORMAT_R11G11B10_FLOAT;
+    game_output.SampleDesc.Count = 1U;
+    game_output.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
+
+    expect(is_dlss_nr_output_compatible(game_output),
+        "DLSS-NR accepts the multi-mip mip-zero output used by ACE");
+}
+
+void test_dlss_nr_maps_right_eye_region_into_packed_output() {
+    using namespace cheeky::foveated_dlss;
+    const auto base = dlss_nr_resource_base(
+        2544U, 928U, 5190U, 0U, false
+    );
+    expect(base.x == 7734U && base.y == 928U,
+        "right-eye DLSS-NR region includes the packed output base");
+    const auto isolated = dlss_nr_resource_base(
+        2544U, 928U, 5190U, 0U, true
+    );
+    expect(isolated.x == 2544U && isolated.y == 928U,
+        "isolated DLSS-NR region remains resource-local");
+}
+
+void test_dlss_nr_reuses_live_sr_crop_center() {
+    using namespace cheeky::foveated_dlss;
+    Settings settings{};
+    settings.nr_use_sr_foveation = true;
+    settings.width = 0.5F;
+    settings.height = 0.5F;
+    settings.x_offset = -0.8F;
+    settings.height_offset = -0.8F;
+    const FoveationGeometry live_sr_crop{
+        1000U, 600U, 1000U, 800U,
+        2000U, 1200U, 2000U, 1600U,
+    };
+    const auto expected = foveation_offsets_from_geometry(
+        live_sr_crop, 3000U, 2000U
+    );
+    const auto parameters = dlss_nr_foveation_parameters(
+        settings, &live_sr_crop, 3000U, 2000U
+    );
+    expect_near(parameters.x_offset, expected.x, 0.0001F,
+        "DLSS-NR follows the live SR horizontal center");
+    expect_near(parameters.y_offset, expected.y, 0.0001F,
+        "DLSS-NR follows the live SR vertical center");
+}
+
 }  // namespace
 
 int main() {
@@ -545,6 +600,9 @@ int main() {
     test_nested_d3d12_lifecycle_scope_is_passthrough();
     test_core_d3d12_route_is_published_to_diagnostics();
     test_multimip_game_output_uses_single_mip_private_output();
+    test_multimip_game_output_is_dlss_nr_compatible();
+    test_dlss_nr_maps_right_eye_region_into_packed_output();
+    test_dlss_nr_reuses_live_sr_crop_center();
     if (failures != 0) {
         std::cerr << failures << " test(s) failed\n";
         return 1;

--- a/tests/gaze_tests.cpp
+++ b/tests/gaze_tests.cpp
@@ -6,6 +6,7 @@
 #include "foveation.hpp"
 #include "gaze_math.hpp"
 #include "gaze_policy.hpp"
+#include "peripheral_dlaa_generation.hpp"
 
 #include <cmath>
 #include <cstdint>
@@ -582,6 +583,25 @@ void test_dlss_nr_reuses_live_sr_crop_center() {
         "DLSS-NR follows the live SR vertical center");
 }
 
+void test_peripheral_dlaa_generation_requires_synchronization() {
+    using namespace cheeky::foveated_dlss;
+    expect(
+        peripheral_dlaa_generation_decision(false, false) ==
+            PeripheralDlaaGenerationDecision::reject,
+        "peripheral DLAA keeps its generation when synchronization fails"
+    );
+    expect(
+        peripheral_dlaa_generation_decision(false, true) ==
+            PeripheralDlaaGenerationDecision::replace,
+        "peripheral DLAA replaces a changed generation after synchronization"
+    );
+    expect(
+        peripheral_dlaa_generation_decision(true, false) ==
+            PeripheralDlaaGenerationDecision::reuse,
+        "peripheral DLAA reuses a compatible generation without synchronization"
+    );
+}
+
 }  // namespace
 
 int main() {
@@ -603,6 +623,7 @@ int main() {
     test_multimip_game_output_is_dlss_nr_compatible();
     test_dlss_nr_maps_right_eye_region_into_packed_output();
     test_dlss_nr_reuses_live_sr_crop_center();
+    test_peripheral_dlaa_generation_requires_synchronization();
     if (failures != 0) {
         std::cerr << failures << " test(s) failed\n";
         return 1;


### PR DESCRIPTION
Fixes #8.

## Summary
- track each peripheral-DLAA command list through ReShade submission using a private-data token
- synchronize old D3D12 resources and NGX features with a per-device fence before replacement
- let stereo views share one completed retirement fence while preserving the current generation when synchronization is unavailable
- add regression coverage for the generation replacement policy

## Verification
- Release build completed successfully
- Existing tests pass
- Live-verified periphery scale changes with dynamic eye tracking active
- Confirmed both eye views hot-load updated dimensions without crashing

## Merge order

All three PRs target `ClarkCheekyKent/CheekyFoveatedDLSS:master`. Merge in this order:
1. [Upstream PR #3](https://github.com/ClarkCheekyKent/CheekyFoveatedDLSS/pull/3) — replaces fork PR #2: DLSS-NR output handling.
2. [Upstream PR #4](https://github.com/ClarkCheekyKent/CheekyFoveatedDLSS/pull/4) — replaces fork PR #3: peripheral DLAA scale hot reload.
3. [Upstream PR #5](https://github.com/ClarkCheekyKent/CheekyFoveatedDLSS/pull/5) — replaces fork PR #5: retain the OpenXR layer for the cached gaze export.

The source branches contain earlier changes in the sequence, so later PR diffs include those changes until they are merged upstream.

This PR is second; merge the replacement for #2 first.

Replaces https://github.com/Williem3/CheekyFoveatedDLSS/pull/3. Hardware validation above is carried over from the original PR. The rebased branch passed a fresh Release build and the automated Cheeky tests; hardware validation has not been repeated.



## Rebase validation

Rebased onto upstream master at 360cb94, preserving merge order #3, then #4, then #5. Earlier eye-tracking prerequisite commits are already upstream and are no longer included in the PR stack. Release build and automated Cheeky tests passed on each of the three rebased branches.

Conflict resolution preserves upstream's peripheral GPU-use tracking, deferred resource retirement, and motion-submission handling. The PR's synchronization and configuration checks remain; replacement waits until upstream has confirmed GPU work submission before synchronizing and releasing the old NGX view.

