### PR TITLE
Add in-overlay issue reporting with diagnostic ZIP and prefilled GitHub form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,41 @@
+name: Bug report
+description: Report a problem with Cheeky Foveated DLSS
+title: "Bug report"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        In the ReShade add-on, click **Report an issue...** to collect a support ZIP.
+        Review the ZIP before sharing: logs can contain personal paths or identifiers.
+        Drag the ZIP selected in Explorer into the **Support ZIP** field below.
+  - type: input
+    id: report
+    attributes:
+      label: Report filename
+      description: Filled automatically when opened from the add-on.
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Filled automatically by the add-on. The ZIP contains the full diagnostic snapshot.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: Include the game name, what you expected, and what happened instead.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Include whether disabling the add-on fixes the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Support ZIP
+      description: Drag the generated ZIP here and wait for the upload to finish. If collection failed, describe the error instead.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -24,14 +24,32 @@ body:
     id: problem
     attributes:
       label: What happened?
-      description: Include the game name, what you expected, and what happened instead.
+      description: Replace the prompts below with your observations. Leave anything you have not checked as "Not tested".
+      value: |
+        **Game and mode:** [Game name; desktop or VR; headset if relevant]
+
+        **What I expected:** [Describe the expected result]
+
+        **What actually happened:** [Describe the visual issue, performance problem, crash, or error message]
+
+        **How often it happens:** [Every time / sometimes / once]
+
+        **With the add-on disabled:** Not tested
     validations:
       required: true
   - type: textarea
     id: steps
     attributes:
       label: Steps to reproduce
-      description: Include whether disabling the add-on fixes the problem.
+      description: Replace these suggestions with the shortest sequence that reproduces the problem. Include any relevant setting changes.
+      value: |
+        1. Launch [game] in [desktop / VR] mode.
+        2. Load [track, level, save, or scene].
+        3. Enable or change [relevant DLSS-SR, DLSS-NR, or eye-tracking settings].
+        4. [Action that triggers the problem].
+        5. Observe [the specific symptom].
+
+        **Workaround, if any:** [Describe it, or write "None known"]
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,6 +7,8 @@ body:
       value: |
         In the ReShade add-on, click **Report an issue...** to collect a support ZIP.
         Review the ZIP before sharing: logs can contain personal paths or identifiers.
+        The add-on copies a detailed report to your clipboard. Paste it into
+        **Diagnostics and settings** with Ctrl+V (or use **Copy detailed report** in the add-on).
         Drag the ZIP selected in Explorer into the **Support ZIP** field below.
   - type: input
     id: report
@@ -30,6 +32,13 @@ body:
     attributes:
       label: Steps to reproduce
       description: Include whether disabling the add-on fixes the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics and settings
+      description: Paste the report copied by the add-on here. It includes system/runtime versions, graphics and OpenXR diagnostics, all add-on settings, and recent log excerpts. Review it before submitting. If collection failed, describe the error.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -38,7 +38,7 @@ body:
     id: diagnostics
     attributes:
       label: Diagnostics and settings
-      description: Filled automatically with system/runtime versions, graphics and OpenXR diagnostics, and all add-on settings. Review before submitting. If the add-on reports a link-size limit, use Copy detailed report and paste it here.
+      description: Filled automatically with system details, feature status, relevant diagnostics, and collapsible settings. The ZIP retains the full diagnostic dump. Review before submitting. If the add-on reports a link-size limit, use Copy detailed report and paste it here.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -24,7 +24,7 @@ body:
     id: problem
     attributes:
       label: What happened?
-      description: Replace the prompts below with your observations. Leave anything you have not checked as "Not tested".
+      description: Confirm the detected game/mode, supply the headset model if using VR, and replace the remaining prompts with your observations. Leave unchecked items as "Not tested".
       value: |
         **Game and mode:** [Game name; desktop or VR; headset if relevant]
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,8 +7,8 @@ body:
       value: |
         In the ReShade add-on, click **Report an issue...** to collect a support ZIP.
         Review the ZIP before sharing: logs can contain personal paths or identifiers.
-        The add-on copies a detailed report to your clipboard. Paste it into
-        **Diagnostics and settings** with Ctrl+V (or use **Copy detailed report** in the add-on).
+        **Diagnostics and settings** is filled automatically by the add-on.
+        **Copy detailed report** also includes recent log excerpts if you want to paste those.
         Drag the ZIP selected in Explorer into the **Support ZIP** field below.
   - type: input
     id: report
@@ -38,7 +38,7 @@ body:
     id: diagnostics
     attributes:
       label: Diagnostics and settings
-      description: Paste the report copied by the add-on here. It includes system/runtime versions, graphics and OpenXR diagnostics, all add-on settings, and recent log excerpts. Review it before submitting. If collection failed, describe the error.
+      description: Filled automatically with system/runtime versions, graphics and OpenXR diagnostics, and all add-on settings. Review before submitting. If the add-on reports a link-size limit, use Copy detailed report and paste it here.
     validations:
       required: true
   - type: textarea

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,7 @@ add_executable(
     CheekyTests
     "${CMAKE_CURRENT_SOURCE_DIR}/tests/gaze_tests.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/tests/d3d12_composite_tests.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tests/support_summary_tests.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/shared/gaze_math.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/foveation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/gaze_policy.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,8 @@ target_link_libraries(
         d3dcompiler
         dxgi
         dxguid
+        shell32
+        version
 )
 
 set_target_properties(

--- a/CheekyTests.vcxproj
+++ b/CheekyTests.vcxproj
@@ -39,6 +39,7 @@
   <ItemGroup>
     <ClCompile Include="tests\gaze_tests.cpp" />
     <ClCompile Include="tests\d3d12_composite_tests.cpp" />
+    <ClCompile Include="tests\support_summary_tests.cpp" />
     <ClCompile Include="shared\gaze_math.cpp" />
     <ClCompile Include="src\foveation.cpp" />
     <ClCompile Include="src\gaze_policy.cpp" />

--- a/README.md
+++ b/README.md
@@ -296,8 +296,14 @@ automatically redacted and may contain personal paths or identifiers; the full
 ReShade configuration is not included. Reports stay on disk until you delete
 them. **Show ZIP** and **Open GitHub issue** let you reopen a prepared report.
 
-The prefilled report includes system and runtime versions, full graphics/OpenXR
-diagnostics and all current add-on settings. `issue-report.md`, saved beside and
+The prefilled report includes system and relevant runtime versions, feature status,
+active graphics-path diagnostics, readable OpenXR status, and all current add-on
+settings in a collapsible section. It flags requested gaze/alignment that was not
+observed at capture time. Unused APIs and disabled DLSS-NR are reduced to status
+lines; duplicate GPU entries, resource addresses, mapping counters, and routine
+system DLL details are omitted from the issue. Zero timings are marked unavailable
+rather than presented as measured zero cost. The full original diagnostic dump
+and system inventory remain in the ZIP. `issue-report.md`, saved beside and
 inside the ZIP, additionally includes log availability and up to 2 KiB of recent
 text from each log. **Review report** opens it; **Copy detailed report** lets you
 paste this extended version if desired. Exceptionally large reports exceeding

--- a/README.md
+++ b/README.md
@@ -282,9 +282,9 @@ before packaging and to the final installer EXE before publishing.
 
 In the ReShade add-on panel, click **Report an issue...**. The add-on prepares a
 support ZIP in `%TEMP%\CheekySupport`, opens a GitHub bug report with a short
-game/version/graphics summary, copies a detailed Markdown report to the clipboard,
-and selects the ZIP in Explorer. Paste the report into **Diagnostics and settings**
-with Ctrl+V, review it, then drag the ZIP into **Support ZIP**. Wait for the upload
+game/version/graphics summary and prefilled **Diagnostics and settings**,
+and selects the ZIP in Explorer. Review the populated report, then drag the ZIP
+into **Support ZIP**. Wait for the upload
 to finish, describe the problem, and submit the issue. Nothing is
 uploaded automatically. A GitHub account is required to submit.
 
@@ -296,12 +296,13 @@ automatically redacted and may contain personal paths or identifiers; the full
 ReShade configuration is not included. Reports stay on disk until you delete
 them. **Show ZIP** and **Open GitHub issue** let you reopen a prepared report.
 
-The pasted report includes system and runtime versions, full graphics/OpenXR
-diagnostics, all current add-on settings, log availability, and up to 2 KiB of
-recent text from each captured log. `issue-report.md` is saved beside the ZIP
-and inside it. **Review report** opens that file; **Copy detailed report** copies
-it again. The detailed report uses the clipboard because GitHub issue links
-cannot reliably carry this much text without exceeding URL limits.
+The prefilled report includes system and runtime versions, full graphics/OpenXR
+diagnostics and all current add-on settings. `issue-report.md`, saved beside and
+inside the ZIP, additionally includes log availability and up to 2 KiB of recent
+text from each log. **Review report** opens it; **Copy detailed report** lets you
+paste this extended version if desired. Exceptionally large reports exceeding
+the 7,800-character encoded URL budget display explicit paste instructions
+instead of opening a broken link. Logs are never placed in the issue URL.
 
 The issue destination is defined in `src/support_report.cpp`. Publish
 `.github/ISSUE_TEMPLATE/bug_report.yml` to that repository's default branch

--- a/README.md
+++ b/README.md
@@ -277,3 +277,24 @@ and uninstall on a Windows test machine; verify that the manifest's DWORD is
 only that value and the installed files. Verify gaze in a supported game after
 restarting it. Release signing, when available, should be applied to the DLL
 before packaging and to the final installer EXE before publishing.
+
+## Reporting a problem
+
+In the ReShade add-on panel, click **Report an issue...**. The add-on prepares a
+support ZIP in `%TEMP%\CheekySupport`, opens a GitHub bug report with a short
+game/version/graphics summary, and selects the
+ZIP in Explorer. Review the archive, drag it into the **Support ZIP** field, wait
+for the upload to finish, describe the problem, and submit the issue. Nothing is
+uploaded automatically. A GitHub account is required to submit.
+
+The archive includes live add-on settings, DX11/DX12 and OpenXR diagnostics,
+system and loaded DLL version information, and available add-on, ReShade, and
+crash logs. Each log is limited to its last 4 MiB; `README.txt` records missing
+or truncated logs. The crash log may be from an earlier session. Logs are not
+automatically redacted and may contain personal paths or identifiers; the full
+ReShade configuration is not included. Reports stay on disk until you delete
+them. **Show ZIP** and **Open GitHub issue** let you reopen a prepared report.
+
+The issue destination is defined in `src/support_report.cpp`. Publish
+`.github/ISSUE_TEMPLATE/bug_report.yml` to that repository's default branch
+before distributing the add-on. Local builds alone do not publish the template.

--- a/README.md
+++ b/README.md
@@ -282,9 +282,10 @@ before packaging and to the final installer EXE before publishing.
 
 In the ReShade add-on panel, click **Report an issue...**. The add-on prepares a
 support ZIP in `%TEMP%\CheekySupport`, opens a GitHub bug report with a short
-game/version/graphics summary, and selects the
-ZIP in Explorer. Review the archive, drag it into the **Support ZIP** field, wait
-for the upload to finish, describe the problem, and submit the issue. Nothing is
+game/version/graphics summary, copies a detailed Markdown report to the clipboard,
+and selects the ZIP in Explorer. Paste the report into **Diagnostics and settings**
+with Ctrl+V, review it, then drag the ZIP into **Support ZIP**. Wait for the upload
+to finish, describe the problem, and submit the issue. Nothing is
 uploaded automatically. A GitHub account is required to submit.
 
 The archive includes live add-on settings, DX11/DX12 and OpenXR diagnostics,
@@ -294,6 +295,13 @@ or truncated logs. The crash log may be from an earlier session. Logs are not
 automatically redacted and may contain personal paths or identifiers; the full
 ReShade configuration is not included. Reports stay on disk until you delete
 them. **Show ZIP** and **Open GitHub issue** let you reopen a prepared report.
+
+The pasted report includes system and runtime versions, full graphics/OpenXR
+diagnostics, all current add-on settings, log availability, and up to 2 KiB of
+recent text from each captured log. `issue-report.md` is saved beside the ZIP
+and inside it. **Review report** opens that file; **Copy detailed report** copies
+it again. The detailed report uses the clipboard because GitHub issue links
+cannot reliably carry this much text without exceeding URL limits.
 
 The issue destination is defined in `src/support_report.cpp`. Publish
 `.github/ISSUE_TEMPLATE/bug_report.yml` to that repository's default branch

--- a/README.md
+++ b/README.md
@@ -310,6 +310,11 @@ paste this extended version if desired. Exceptionally large reports exceeding
 the 7,800-character encoded URL budget display explicit paste instructions
 instead of opening a broken link. Logs are never placed in the issue URL.
 
+The description and reproduction prompts prefill the game executable and VR mode
+when compatible OpenXR session/mapping activity is detected. Otherwise the user
+is asked to confirm desktop or VR. The runtime name is shown separately; the
+current diagnostic interface does not expose a headset model, so users supply it.
+
 The issue destination is defined in `src/support_report.cpp`. Publish
 `.github/ISSUE_TEMPLATE/bug_report.yml` to that repository's default branch
 before distributing the add-on. Local builds alone do not publish the template.

--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -6,6 +6,7 @@
 #include "gaze_foveation.hpp"
 #include "runtime.hpp"
 #include "settings.hpp"
+#include "support_report.hpp"
 #include "cheeky_gaze_abi.h"
 #include "version.h"
 
@@ -1576,6 +1577,8 @@ void draw_settings_overlay(reshade::api::effect_runtime*) {
         save_settings_to_reshade(settings);
     }
 
+    draw_support_report(addon_module.load(std::memory_order_acquire));
+
     if (ImGui::CollapsingHeader(
             "Diagnostics",
             ImGuiTreeNodeFlags_DefaultOpen
@@ -1899,6 +1902,7 @@ extern "C" __declspec(dllexport) void AddonUninit(
         &on_execute_command_list
     );
     reshade::unregister_overlay(nullptr, &draw_settings_overlay);
+    finish_support_report();
     stop_interception();
     release_d3d11_d3d12_transport();
     release_d3d11_resources();

--- a/src/support_prompts.hpp
+++ b/src/support_prompts.hpp
@@ -1,0 +1,26 @@
+#pragma once
+#include <string>
+
+namespace cheeky::foveated_dlss {
+struct SupportPrompts { std::string problem, steps; };
+inline SupportPrompts support_prompts(const std::string& game, bool openxr_activity,
+                                     const std::string& runtime) {
+    const std::string mode = openxr_activity ? "VR (OpenXR activity detected)"
+        : "Not detected - confirm desktop or VR";
+    std::string problem = "**Game executable:** " + game + "\n\n**Mode:** " + mode;
+    if (!runtime.empty()) problem += "\n\n**OpenXR runtime:** " + runtime;
+    problem += "\n\n**Headset:** Not detected - enter model if using VR; otherwise N/A"
+        "\n\n**What I expected:** [Describe the expected result]"
+        "\n\n**What actually happened:** [Describe the symptom or error]"
+        "\n\n**How often it happens:** [Every time / sometimes / once]"
+        "\n\n**With the add-on disabled:** Not tested";
+    const std::string launch_mode = openxr_activity ? "VR" : "[desktop / VR]";
+    return {problem,
+        "1. Launch " + game + " in " + launch_mode + " mode.\n"
+        "2. Load [track, level, save, or scene].\n"
+        "3. [Any relevant setting changes; captured settings are listed below].\n"
+        "4. [Action that triggers the problem].\n"
+        "5. Observe [the specific symptom].\n\n"
+        "**Workaround, if any:** [Describe it, or write None known]"};
+}
+}

--- a/src/support_report.cpp
+++ b/src/support_report.cpp
@@ -28,7 +28,7 @@ namespace cheeky::foveated_dlss {
 namespace {
 namespace fs = std::filesystem;
 constexpr wchar_t issue_base[] =
-    L"https://github.com/Williem3/CheekyFoveatedDLSS/issues/new?template=bug_report.yml";
+    L"https://github.com/ClarkCheekyKent/CheekyFoveatedDLSS/issues/new?template=bug_report.yml";
 struct PreparedReport { fs::path zip; std::string markdown; };
 std::future<PreparedReport> pending;
 fs::path last_zip;

--- a/src/support_report.cpp
+++ b/src/support_report.cpp
@@ -27,8 +27,10 @@ namespace {
 namespace fs = std::filesystem;
 constexpr wchar_t issue_base[] =
     L"https://github.com/Williem3/CheekyFoveatedDLSS/issues/new?template=bug_report.yml";
-std::future<fs::path> pending;
+struct PreparedReport { fs::path zip; std::string markdown; };
+std::future<PreparedReport> pending;
 fs::path last_zip;
+std::string last_markdown;
 std::string status;
 std::string pending_summary, last_summary;
 
@@ -150,7 +152,7 @@ std::string diagnostics_text() {
         out << "received_output_height=" << d.received_output_height << '\n';
         out << "motion_vector_width=" << d.motion_vector_width << '\n';
         out << "motion_vector_height=" << d.motion_vector_height << '\n';
-        out << "motion_vector_space=" << static_cast<unsigned>(d.motion_vector_space) << '\n';
+        out << "motion_vector_space=" << motion_vector_space_name(d.motion_vector_space) << '\n';
         out << "transport_gpu_ms=" << d.transport_gpu_ms << '\n';
         out << "foveated_dlss_gpu_ms=" << d.foveated_dlss_gpu_ms << '\n';
         out << "peripheral_dlaa_gpu_ms=" << d.peripheral_dlaa_gpu_ms << '\n';
@@ -161,11 +163,11 @@ std::string diagnostics_text() {
         out << "native_frame_ms=" << d.native_frame_ms << '\n';
         out << "has_private_result=" << d.has_private_result << '\n';
         out << "last_private_result=" << d.last_private_result << '\n';
-        out << "last_result=" << d.last_result << '\n';
+        out << "last_result=0x" << std::hex << d.last_result << std::dec << '\n';
         out << "state=" << static_cast<unsigned>(d.state) << '\n';
         out << "d3d11_execution_path=" << static_cast<unsigned>(d.d3d11_execution_path) << '\n';
         out << "d3d11_transport_status=" << static_cast<unsigned>(d.d3d11_transport_status) << '\n';
-        out << "d3d12_ngx_route=" << static_cast<unsigned>(d.d3d12_ngx_route) << '\n';
+        out << "d3d12_ngx_route=" << d3d12_ngx_route_name(d.d3d12_ngx_route) << '\n';
         out << "state_name=" << diagnostic_state_name(d.state) << '\n'
             << "execution_path=" << d3d11_execution_path_name(d.d3d11_execution_path) << '\n'
             << "transport_status=" << d3d11_transport_status_name(d.d3d11_transport_status) << '\n';
@@ -187,8 +189,9 @@ std::string diagnostics_text() {
     out << "using_gaze=" << g.using_gaze << '\n';
     out << "mapping_ambiguous=" << g.mapping_ambiguous << '\n';
     out << "last_reset_reason=" << static_cast<unsigned>(g.last_reset_reason) << '\n';
-    for (const auto& v : g.views) {
-        out << "\n[Eye]\n";
+    for (std::size_t eye = 0; eye < g.views.size(); ++eye) {
+        const auto& v = g.views[eye];
+        out << "\n[Eye " << eye << "]\n";
         out << "center_u=" << v.center_u << '\n';
         out << "center_v=" << v.center_v << '\n';
         out << "dlss_view_id=" << v.dlss_view_id << '\n';
@@ -219,7 +222,7 @@ std::string diagnostics_text() {
     const auto nr = dlss_nr_snapshot();
     out << "\n[DLSS-NR]\n";
     out << "state=" << dlss_nr_state_name(nr.state) << '\n';
-    out << "route=" << static_cast<unsigned>(nr.route) << '\n';
+    out << "route=" << dlss_nr_route_name(nr.route) << '\n';
     out << "candidate_calls=" << nr.candidate_calls << '\n';
     out << "evaluation_calls=" << nr.evaluation_calls << '\n';
     out << "failed_calls=" << nr.failed_calls << '\n';
@@ -269,7 +272,49 @@ void collect_log(std::vector<SupportFile>& files, std::ostringstream& manifest,
     files.push_back({name, std::move(contents)});
 }
 
-fs::path create_report(const fs::path& addon, const fs::path& game,
+// Use a fence longer than any backtick run in captured text, so logs cannot
+// accidentally terminate a code block and alter the report's Markdown structure.
+std::string code_block(const std::string& text) {
+    std::size_t longest{}, run{};
+    for (const char c : text) {
+        run = c == '`' ? run + 1 : 0;
+        longest = (std::max)(longest, run);
+    }
+    const std::string fence((std::max)(std::size_t{3}, longest + 1), '`');
+    return fence + "text\n" + text + "\n" + fence + "\n\n";
+}
+
+std::string issue_markdown(const std::vector<SupportFile>& files) {
+    std::string report = "## Automatically collected report\n\n";
+    for (const auto& section : {
+            std::pair{"system.txt", "System and runtime versions"},
+            std::pair{"diagnostics.txt", "Graphics, DLSS and OpenXR diagnostics"},
+            std::pair{"settings.ini", "All current add-on settings"},
+            std::pair{"README.txt", "Capture details and log availability"}}) {
+        for (const auto& file : files) {
+            if (file.name == section.first)
+                report += std::string("### ") + section.second + "\n\n" + code_block(file.contents);
+        }
+    }
+    report += "### Recent log excerpts\n\nFull captured logs are in the attached ZIP. "
+              "Excerpts below contain up to the last 2 KiB of each available log.\n\n";
+    bool has_logs{};
+    for (const auto& file : files) {
+        if (!file.name.ends_with(".log")) continue;
+        has_logs = true;
+        auto excerpt = file.contents.substr(file.contents.size() > 2048 ? file.contents.size() - 2048 : 0);
+        if (file.contents.size() > 2048) {
+            const auto newline = excerpt.find('\n');
+            if (newline != std::string::npos) excerpt.erase(0, newline + 1);
+            excerpt = "[earlier log content omitted]\n" + excerpt;
+        }
+        report += "#### " + file.name + "\n\n" + code_block(excerpt.empty() ? "(empty)" : excerpt);
+    }
+    if (!has_logs) report += "No logs were available; see capture details above.\n";
+    return report;
+}
+
+PreparedReport create_report(const fs::path& addon, const fs::path& game,
                        std::string settings, std::string diagnostics) {
     std::array<wchar_t, 32768> temp{};
     const auto size = GetTempPathW(static_cast<DWORD>(temp.size()), temp.data());
@@ -299,7 +344,7 @@ fs::path create_report(const fs::path& addon, const fs::path& game,
 
     std::ostringstream system;
     system << "Game: " << utf8(game.filename().wstring()) << "\nGame version: " << file_version(game)
-           << "\nAdd-on version: " << file_version(addon) << '\n';
+           << "\nAdd-on version: " << CHEEKY_VERSION << "\nArchitecture: 64-bit\n";
     using RtlVersionFn = LONG(WINAPI*)(PRTL_OSVERSIONINFOW);
     const auto rtl = reinterpret_cast<RtlVersionFn>(GetProcAddress(GetModuleHandleW(L"ntdll.dll"), "RtlGetVersion"));
     RTL_OSVERSIONINFOW os{};
@@ -323,17 +368,37 @@ fs::path create_report(const fs::path& addon, const fs::path& game,
         }
         factory->Release();
     }
-    for (const auto dll : {L"nvngx_dlss.dll", L"nvngx_dlssnr.dll", L"CheekyOpenXRLayer.dll", L"dxgi.dll", L"d3d11.dll"}) {
-        if (const auto module = GetModuleHandleW(dll))
-            system << utf8(dll) << ": " << file_version(module_path(module)) << '\n';
+    system << "\nRelevant runtime files (loaded status and on-disk presence are separate):\n";
+    for (const auto dll : {L"nvngx_dlss.dll", L"nvngx_dlssnr.dll", L"CheekyOpenXRLayer.dll",
+                           L"ReShade64.dll", L"dxgi.dll", L"d3d11.dll", L"sl.interposer.dll", L"sl.dlss.dll"}) {
+        system << utf8(dll) << ": ";
+        if (const auto module = GetModuleHandleW(dll)) {
+            system << "loaded, version " << file_version(module_path(module));
+        } else {
+            system << "not loaded";
+        }
+        std::error_code error;
+        const bool by_game = fs::exists(game.parent_path() / dll, error);
+        error.clear();
+        const bool by_addon = fs::exists(addon.parent_path() / dll, error);
+        system << "; beside game=" << (by_game ? "present" : "absent")
+               << "; beside add-on=" << (by_addon ? "present" : "absent") << '\n';
     }
     files.push_back({"system.txt", system.str()});
     files.push_back({"README.txt", manifest.str()});
+    auto markdown = issue_markdown(files);
+    {
+        std::ofstream preview(folder / L"issue-report.md", std::ios::binary);
+        preview.exceptions(std::ios::failbit | std::ios::badbit);
+        preview.write(markdown.data(), markdown.size());
+        preview.close();
+    }
+    files.push_back({"issue-report.md", markdown});
     const auto partial = folder / L"report.partial";
     const auto zip = folder / (std::wstring(name) + L".zip");
     write_support_zip(partial, files);
     fs::rename(partial, zip);
-    return zip;
+    return {zip, std::move(markdown)};
 }
 
 bool open_target(const wchar_t* target, const wchar_t* args = nullptr) {
@@ -359,14 +424,17 @@ void open_issue() {
 void draw_support_report(HMODULE addon) {
     try {
         if (pending.valid() && pending.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
-            last_zip = pending.get();
+            auto report = pending.get();
+            last_zip = std::move(report.zip);
+            last_markdown = std::move(report.markdown);
             last_summary = pending_summary;
-            status = "Report prepared. Drag the selected ZIP into the GitHub issue, describe the problem, then submit.";
+            ImGui::SetClipboardText(last_markdown.c_str());
+            status = "Report copied. Paste (Ctrl+V) into Diagnostics and settings on GitHub, then drag the selected ZIP into Support ZIP.";
             open_issue();
             show_zip();
         }
         ImGui::SeparatorText("Report a problem");
-        ImGui::TextWrapped("Collect logs, settings and diagnostics into a ZIP. Review it before attaching; logs may contain personal paths. Nothing uploads automatically.");
+        ImGui::TextWrapped("Prepare a detailed issue report and ZIP. The report is copied to your clipboard for pasting into GitHub. Review before sharing; logs may contain personal paths. Nothing uploads automatically.");
         ImGui::BeginDisabled(pending.valid());
         const bool clicked = ImGui::Button("Report an issue...");
         ImGui::EndDisabled();
@@ -387,6 +455,15 @@ void draw_support_report(HMODULE addon) {
         if (!last_zip.empty()) {
             ImGui::TextWrapped("%s", utf8(last_zip.wstring()).c_str());
             if (ImGui::Button("Show ZIP")) show_zip();
+            ImGui::SameLine();
+            if (ImGui::Button("Copy detailed report")) {
+                ImGui::SetClipboardText(last_markdown.c_str());
+                status = "Detailed report copied. Paste into Diagnostics and settings on GitHub.";
+            }
+            if (ImGui::Button("Review report")) {
+                const auto preview = last_zip.parent_path() / L"issue-report.md";
+                if (!open_target(preview.c_str())) status = "Could not open report. Find issue-report.md beside the ZIP.";
+            }
             ImGui::SameLine();
             if (ImGui::Button("Open GitHub issue")) open_issue();
             ImGui::SameLine();

--- a/src/support_report.cpp
+++ b/src/support_report.cpp
@@ -1,5 +1,6 @@
 #include "support_report.hpp"
 #include "support_zip.hpp"
+#include "support_summary.hpp"
 #include "diagnostics.hpp"
 #include "dlss_nr.hpp"
 #include "gaze_foveation.hpp"
@@ -285,17 +286,12 @@ std::string code_block(const std::string& text) {
 }
 
 std::string issue_markdown(const std::vector<SupportFile>& files) {
-    std::string report = "## Automatically collected report\n\n";
-    for (const auto& section : {
-            std::pair{"system.txt", "System and runtime versions"},
-            std::pair{"diagnostics.txt", "Graphics, DLSS and OpenXR diagnostics"},
-            std::pair{"settings.ini", "All current add-on settings"},
-            std::pair{"README.txt", "Capture details and log availability"}}) {
-        for (const auto& file : files) {
-            if (file.name == section.first)
-                report += std::string("### ") + section.second + "\n\n" + code_block(file.contents);
-        }
-    }
+    auto contents = [&](const char* name) {
+        for (const auto& file : files) if (file.name == name) return file.contents;
+        return std::string{};
+    };
+    std::string report = support_summary(contents("system.txt"), contents("diagnostics.txt"), contents("settings.ini"));
+    report += "### Capture details and log availability\n\n" + code_block(contents("README.txt"));
     report += "### Recent log excerpts\n\nFull captured logs are in the attached ZIP. "
               "Excerpts below contain up to the last 2 KiB of each available log.\n\n";
     bool has_logs{};

--- a/src/support_report.cpp
+++ b/src/support_report.cpp
@@ -411,12 +411,24 @@ void show_zip() {
 }
 
 std::wstring issue_url() {
-    return std::wstring(issue_base) + L"&title=Bug%20report&report=" +
+    auto url = std::wstring(issue_base) + L"&title=Bug%20report&report=" +
         url_encode(utf8(last_zip.filename().wstring())) + L"&environment=" + url_encode(last_summary);
+    // Settings and diagnostics fit in a normal issue URL. Keep the potentially
+    // huge log excerpts and capture manifest in the ZIP/copyable report only.
+    const auto end = last_markdown.find("### Capture details and log availability");
+    const auto details = last_markdown.substr(0, end);
+    const auto populated = url + L"&diagnostics=" + url_encode(details);
+    if (populated.size() <= 7800) return populated;
+    // Exceptional oversized hardware/runtime descriptions must not produce a
+    // broken GitHub URL. Make the fallback visible in the field and overlay.
+    return url + L"&diagnostics=" + url_encode(
+        "This report exceeds the issue-link size limit. Use Copy detailed report in the add-on and paste it here.");
 }
 
 void open_issue() {
     const auto url = issue_url();
+    if (url.find(L"exceeds%20the%20issue-link") != std::wstring::npos)
+        status = "Report exceeds the link size limit. Use Copy detailed report and paste into Diagnostics and settings; attach the ZIP.";
     if (!open_target(url.c_str())) status = "Could not open browser. Use Copy issue link and open it manually.";
 }
 }
@@ -428,13 +440,12 @@ void draw_support_report(HMODULE addon) {
             last_zip = std::move(report.zip);
             last_markdown = std::move(report.markdown);
             last_summary = pending_summary;
-            ImGui::SetClipboardText(last_markdown.c_str());
-            status = "Report copied. Paste (Ctrl+V) into Diagnostics and settings on GitHub, then drag the selected ZIP into Support ZIP.";
+            status = "Diagnostics and settings are prefilled on GitHub. Review them, then drag the selected ZIP into Support ZIP.";
             open_issue();
             show_zip();
         }
         ImGui::SeparatorText("Report a problem");
-        ImGui::TextWrapped("Prepare a detailed issue report and ZIP. The report is copied to your clipboard for pasting into GitHub. Review before sharing; logs may contain personal paths. Nothing uploads automatically.");
+        ImGui::TextWrapped("Open a GitHub issue with system information, diagnostics and settings filled in, and prepare a ZIP of the logs. Review before submitting; logs may contain personal paths.");
         ImGui::BeginDisabled(pending.valid());
         const bool clicked = ImGui::Button("Report an issue...");
         ImGui::EndDisabled();

--- a/src/support_report.cpp
+++ b/src/support_report.cpp
@@ -1,0 +1,403 @@
+#include "support_report.hpp"
+#include "support_zip.hpp"
+#include "diagnostics.hpp"
+#include "dlss_nr.hpp"
+#include "gaze_foveation.hpp"
+#include "settings.hpp"
+#include "version.h"
+
+#define ImTextureID ImU64
+#include <imgui.h>
+#include <reshade.hpp>
+#include <shellapi.h>
+#include <dxgi.h>
+#include <winternl.h>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <future>
+#include <sstream>
+
+#pragma comment(lib, "shell32.lib")
+#pragma comment(lib, "version.lib")
+
+namespace cheeky::foveated_dlss {
+namespace {
+namespace fs = std::filesystem;
+constexpr wchar_t issue_base[] =
+    L"https://github.com/Williem3/CheekyFoveatedDLSS/issues/new?template=bug_report.yml";
+std::future<fs::path> pending;
+fs::path last_zip;
+std::string status;
+std::string pending_summary, last_summary;
+
+std::wstring url_encode(const std::string& text) {
+    constexpr wchar_t hex[] = L"0123456789ABCDEF";
+    std::wstring result;
+    for (unsigned char c : text) {
+        if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+            (c >= '0' && c <= '9') || c == '-' || c == '_' || c == '.' || c == '~') {
+            result += static_cast<wchar_t>(c);
+        } else {
+            result += L'%'; result += hex[c >> 4]; result += hex[c & 15];
+        }
+    }
+    return result;
+}
+
+std::string utf8(const std::wstring& value) {
+    if (value.empty()) return {};
+    const int size = WideCharToMultiByte(CP_UTF8, 0, value.data(),
+        static_cast<int>(value.size()), nullptr, 0, nullptr, nullptr);
+    std::string result(size, '\0');
+    WideCharToMultiByte(CP_UTF8, 0, value.data(), static_cast<int>(value.size()),
+        result.data(), size, nullptr, nullptr);
+    return result;
+}
+
+fs::path module_path(HMODULE module) {
+    std::wstring path(32768, L'\0');
+    const auto size = GetModuleFileNameW(module, path.data(), static_cast<DWORD>(path.size()));
+    if (!size || size >= path.size()) throw std::runtime_error("Cannot locate module");
+    path.resize(size);
+    return path;
+}
+
+std::string file_version(const fs::path& path) {
+    DWORD unused{};
+    const auto size = GetFileVersionInfoSizeW(path.c_str(), &unused);
+    if (!size) return "unavailable";
+    std::vector<char> data(size);
+    VS_FIXEDFILEINFO* info{};
+    UINT length{};
+    if (!GetFileVersionInfoW(path.c_str(), 0, size, data.data()) ||
+        !VerQueryValueW(data.data(), L"\\", reinterpret_cast<void**>(&info), &length) ||
+        length < sizeof(VS_FIXEDFILEINFO)) return "unavailable";
+    std::ostringstream out;
+    out << HIWORD(info->dwFileVersionMS) << '.' << LOWORD(info->dwFileVersionMS)
+        << '.' << HIWORD(info->dwFileVersionLS) << '.' << LOWORD(info->dwFileVersionLS);
+    return out.str();
+}
+
+std::string settings_text(const Settings& s) {
+    std::ostringstream out;
+    out << std::boolalpha << "[CheekyFoveatedDLSS]\n";
+    out << "enabled=" << s.enabled << '\n';
+    out << "d3d11_use_d3d12_transport=" << s.d3d11_use_d3d12_transport << '\n';
+    out << "peripheral_dlaa_enabled=" << s.peripheral_dlaa_enabled << '\n';
+    out << "peripheral_dlaa_scale=" << s.peripheral_dlaa_scale << '\n';
+    out << "center_preset=" << s.center_preset << '\n';
+    out << "peripheral_dlaa_preset=" << s.peripheral_dlaa_preset << '\n';
+    out << "width=" << s.width << '\n';
+    out << "height=" << s.height << '\n';
+    out << "x_offset=" << s.x_offset << '\n';
+    out << "height_offset=" << s.height_offset << '\n';
+    out << "invert_stereo_x_offset=" << s.invert_stereo_x_offset << '\n';
+    out << "auto_stereo_alignment=" << s.auto_stereo_alignment << '\n';
+    out << "aligned_height_offset=" << s.aligned_height_offset << '\n';
+    out << "roundness=" << s.roundness << '\n';
+    out << "transition_width=" << s.transition_width << '\n';
+    out << "alignment_border_enabled=" << s.alignment_border_enabled << '\n';
+    out << "center_mode=" << static_cast<unsigned>(s.center_mode) << '\n';
+    out << "simulation_pattern=" << s.simulation_pattern << '\n';
+    out << "show_next_jump_target=" << s.show_next_jump_target << '\n';
+    out << "gaze_smoothing_ms=" << s.gaze_smoothing_ms << '\n';
+    out << "gaze_quantization_pixels=" << s.gaze_quantization_pixels << '\n';
+    out << "gaze_jump_reset_ratio=" << s.gaze_jump_reset_ratio << '\n';
+    out << "nr_enabled=" << s.nr_enabled << '\n';
+    out << "nr_foveated=" << s.nr_foveated << '\n';
+    out << "nr_use_sr_foveation=" << s.nr_use_sr_foveation << '\n';
+    out << "nr_alignment_border_enabled=" << s.nr_alignment_border_enabled << '\n';
+    out << "nr_width=" << s.nr_width << '\n';
+    out << "nr_height=" << s.nr_height << '\n';
+    out << "nr_roundness=" << s.nr_roundness << '\n';
+    out << "nr_transition_width=" << s.nr_transition_width << '\n';
+    out << "nr_working_scale=" << s.nr_working_scale << '\n';
+    out << "nr_preset=" << s.nr_preset << '\n';
+    out << "nr_intensity=" << s.nr_intensity << '\n';
+    out << "nr_local_tone_strength=" << s.nr_local_tone_strength << '\n';
+    out << "nr_local_structure_strength=" << s.nr_local_structure_strength << '\n';
+    out << "nr_skin_structure_strength=" << s.nr_skin_structure_strength << '\n';
+    out << "nr_automatic_mask=" << s.nr_automatic_mask << '\n';
+    out << "nr_ui_correction=" << s.nr_ui_correction << '\n';
+    out << "nr_paper_white_scale=" << s.nr_paper_white_scale << '\n';
+    out << "nr_hdr_transfer_strength=" << s.nr_hdr_transfer_strength << '\n';
+    out << "nr_color_strength=" << s.nr_color_strength << '\n';
+    out << "nr_depth_convention=" << s.nr_depth_convention << '\n';
+    out << "nr_motion_scale_x_multiplier=" << s.nr_motion_scale_x_multiplier << '\n';
+    out << "nr_motion_scale_y_multiplier=" << s.nr_motion_scale_y_multiplier << '\n';
+    return out.str();
+}
+
+std::string diagnostics_text() {
+    std::ostringstream out;
+    out << std::boolalpha << "Report schema: 1\nAdd-on: " << CHEEKY_VERSION
+        << "\nBuild: " << __DATE__ << ' ' << __TIME__ << '\n';
+    for (const auto api : {DiagnosticApi::d3d11, DiagnosticApi::d3d12}) {
+        const auto d = diagnostic_snapshot(api);
+        out << "\n[" << (api == DiagnosticApi::d3d11 ? "DX11" : "DX12") << "]\n";
+        out << "runtime_loaded=" << d.runtime_loaded << '\n';
+        out << "streamline_detected=" << d.streamline_detected << '\n';
+        out << "hook_discovered=" << d.hook_discovered << '\n';
+        out << "direct_detour_installed=" << d.direct_detour_installed << '\n';
+        out << "create_calls=" << d.create_calls << '\n';
+        out << "evaluate_calls=" << d.evaluate_calls << '\n';
+        out << "active_calls=" << d.active_calls << '\n';
+        out << "received_input_width=" << d.received_input_width << '\n';
+        out << "received_input_height=" << d.received_input_height << '\n';
+        out << "received_output_width=" << d.received_output_width << '\n';
+        out << "received_output_height=" << d.received_output_height << '\n';
+        out << "motion_vector_width=" << d.motion_vector_width << '\n';
+        out << "motion_vector_height=" << d.motion_vector_height << '\n';
+        out << "motion_vector_space=" << static_cast<unsigned>(d.motion_vector_space) << '\n';
+        out << "transport_gpu_ms=" << d.transport_gpu_ms << '\n';
+        out << "foveated_dlss_gpu_ms=" << d.foveated_dlss_gpu_ms << '\n';
+        out << "peripheral_dlaa_gpu_ms=" << d.peripheral_dlaa_gpu_ms << '\n';
+        out << "full_dlss_nr_gpu_ms=" << d.full_dlss_nr_gpu_ms << '\n';
+        out << "foveated_dlss_nr_gpu_ms=" << d.foveated_dlss_nr_gpu_ms << '\n';
+        out << "native_dlss_gpu_ms=" << d.native_dlss_gpu_ms << '\n';
+        out << "foveated_frame_ms=" << d.foveated_frame_ms << '\n';
+        out << "native_frame_ms=" << d.native_frame_ms << '\n';
+        out << "has_private_result=" << d.has_private_result << '\n';
+        out << "last_private_result=" << d.last_private_result << '\n';
+        out << "last_result=" << d.last_result << '\n';
+        out << "state=" << static_cast<unsigned>(d.state) << '\n';
+        out << "d3d11_execution_path=" << static_cast<unsigned>(d.d3d11_execution_path) << '\n';
+        out << "d3d11_transport_status=" << static_cast<unsigned>(d.d3d11_transport_status) << '\n';
+        out << "d3d12_ngx_route=" << static_cast<unsigned>(d.d3d12_ngx_route) << '\n';
+        out << "state_name=" << diagnostic_state_name(d.state) << '\n'
+            << "execution_path=" << d3d11_execution_path_name(d.d3d11_execution_path) << '\n'
+            << "transport_status=" << d3d11_transport_status_name(d.d3d11_transport_status) << '\n';
+        const auto& c = d.passed_crop;
+        out << "input_crop=" << c.input_base_x << ',' << c.input_base_y << ','
+            << c.input_width << ',' << c.input_height << '\n'
+            << "output_crop=" << c.output_base_x << ',' << c.output_base_y << ','
+            << c.output_width << ',' << c.output_height << '\n';
+    }
+    const auto g = gaze_diagnostics();
+    out << "\n[OpenXR]\n";
+    out << "runtime_name=" << g.runtime_name << '\n';
+    out << "submitted_copies=" << g.submitted_copies << '\n';
+    out << "alignment_source=" << g.alignment_source << '\n';
+    out << "status_flags=" << g.status_flags << '\n';
+    out << "sample_age_ms=" << g.sample_age_ms << '\n';
+    out << "layer_present=" << g.layer_present << '\n';
+    out << "abi_compatible=" << g.abi_compatible << '\n';
+    out << "using_gaze=" << g.using_gaze << '\n';
+    out << "mapping_ambiguous=" << g.mapping_ambiguous << '\n';
+    out << "last_reset_reason=" << static_cast<unsigned>(g.last_reset_reason) << '\n';
+    for (const auto& v : g.views) {
+        out << "\n[Eye]\n";
+        out << "center_u=" << v.center_u << '\n';
+        out << "center_v=" << v.center_v << '\n';
+        out << "dlss_view_id=" << v.dlss_view_id << '\n';
+        out << "stable_matches=" << v.stable_matches << '\n';
+        out << "crop_delta_x=" << v.crop_delta_x << '\n';
+        out << "crop_delta_y=" << v.crop_delta_y << '\n';
+        out << "xr_resource=" << v.xr_resource << '\n';
+        out << "xr_x=" << v.xr_x << '\n';
+        out << "xr_width=" << v.xr_width << '\n';
+        out << "candidate_view=" << v.candidate_view << '\n';
+        out << "candidate_x=" << v.candidate_x << '\n';
+        out << "has_candidate=" << v.has_candidate << '\n';
+        out << "resource_mapped=" << v.resource_mapped << '\n';
+        out << "packed_stereo_mapping=" << v.packed_stereo_mapping << '\n';
+        out << "xr_y=" << v.xr_y << '\n';
+        out << "xr_height=" << v.xr_height << '\n';
+        out << "xr_array=" << v.xr_array << '\n';
+        out << "candidate_resource=" << v.candidate_resource << '\n';
+        out << "candidate_y=" << v.candidate_y << '\n';
+        out << "candidate_width=" << v.candidate_width << '\n';
+        out << "candidate_height=" << v.candidate_height << '\n';
+        out << "copy_mapping=" << v.copy_mapping << '\n';
+        out << "projection_mapping=" << v.projection_mapping << '\n';
+        out << "alignment_source=" << v.alignment_source << '\n';
+        out << "aligned_u=" << v.aligned_u << '\n';
+        out << "aligned_v=" << v.aligned_v << '\n';
+    }
+    const auto nr = dlss_nr_snapshot();
+    out << "\n[DLSS-NR]\n";
+    out << "state=" << dlss_nr_state_name(nr.state) << '\n';
+    out << "route=" << static_cast<unsigned>(nr.route) << '\n';
+    out << "candidate_calls=" << nr.candidate_calls << '\n';
+    out << "evaluation_calls=" << nr.evaluation_calls << '\n';
+    out << "failed_calls=" << nr.failed_calls << '\n';
+    out << "last_result=" << nr.last_result << '\n';
+    out << "output_width=" << nr.output_width << '\n';
+    out << "output_height=" << nr.output_height << '\n';
+    out << "region_base_x=" << nr.region_base_x << '\n';
+    out << "region_base_y=" << nr.region_base_y << '\n';
+    out << "region_width=" << nr.region_width << '\n';
+    out << "region_height=" << nr.region_height << '\n';
+    out << "working_width=" << nr.working_width << '\n';
+    out << "working_height=" << nr.working_height << '\n';
+    out << "intermediate_vram_bytes=" << nr.intermediate_vram_bytes << '\n';
+    return out.str();
+}
+
+// Only a tail is read, including when a log is still open in the game.
+void collect_log(std::vector<SupportFile>& files, std::ostringstream& manifest,
+                 const fs::path& source, const std::string& name) {
+    const HANDLE file = CreateFileW(source.c_str(), GENERIC_READ,
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr,
+        OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (file == INVALID_HANDLE_VALUE) {
+        manifest << name << ": unavailable (Windows error " << GetLastError() << ")\n";
+        return;
+    }
+    LARGE_INTEGER size{};
+    constexpr LONGLONG limit = 4 * 1024 * 1024;
+    if (!GetFileSizeEx(file, &size)) {
+        manifest << name << ": size unavailable\n";
+        CloseHandle(file); return;
+    }
+    LARGE_INTEGER start{};
+    start.QuadPart = (std::max)(0LL, size.QuadPart - limit);
+    if (!SetFilePointerEx(file, start, nullptr, FILE_BEGIN)) {
+        manifest << name << ": seek failed\n";
+        CloseHandle(file); return;
+    }
+    std::string contents(static_cast<std::size_t>(size.QuadPart - start.QuadPart), '\0');
+    DWORD read{};
+    const bool ok = ReadFile(file, contents.data(), static_cast<DWORD>(contents.size()), &read, nullptr) != FALSE;
+    CloseHandle(file);
+    if (!ok) { manifest << name << ": read failed\n"; return; }
+    contents.resize(read);
+    manifest << name << ": " << read << " bytes; "
+             << (start.QuadPart ? "truncated to last 4 MiB" : "complete at capture") << '\n';
+    files.push_back({name, std::move(contents)});
+}
+
+fs::path create_report(const fs::path& addon, const fs::path& game,
+                       std::string settings, std::string diagnostics) {
+    std::array<wchar_t, 32768> temp{};
+    const auto size = GetTempPathW(static_cast<DWORD>(temp.size()), temp.data());
+    if (!size || size >= temp.size()) throw std::runtime_error("Cannot locate temporary directory");
+    const fs::path root = fs::path(temp.data()) / L"CheekySupport";
+    fs::create_directories(root);
+    SYSTEMTIME now{};
+    GetSystemTime(&now);
+    wchar_t name[100]{};
+    swprintf_s(name, L"Cheeky-report-%04u%02u%02u-%02u%02u%02u-%03u-%lu",
+        now.wYear, now.wMonth, now.wDay, now.wHour, now.wMinute, now.wSecond,
+        now.wMilliseconds, GetCurrentProcessId());
+    const fs::path folder = root / name;
+    if (!fs::create_directory(folder)) throw std::runtime_error("Report folder already exists; retry");
+    std::vector<SupportFile> files{{"settings.ini", std::move(settings)},
+                                 {"diagnostics.txt", std::move(diagnostics)}};
+    std::ostringstream manifest;
+    manifest << "Capture time (UTC): " << utf8(name) << "\n"
+        << "Review before attaching: logs may contain personal paths or identifiers.\n"
+        << "Only add-on settings are exported; ReShade.ini is not included.\n"
+        << "The crash log is optional and may belong to an earlier game session.\n\n";
+    collect_log(files, manifest, addon.parent_path() / L"CheekyFoveatedDLSS.log", "CheekyFoveatedDLSS.log");
+    collect_log(files, manifest, game.parent_path() / L"ReShade.log", "ReShade-game.log");
+    if (addon.parent_path() != game.parent_path())
+        collect_log(files, manifest, addon.parent_path() / L"ReShade.log", "ReShade-addon.log");
+    collect_log(files, manifest, fs::path(temp.data()) / L"CheekyFoveatedDLSS_crash.log", "CheekyFoveatedDLSS_crash.log");
+
+    std::ostringstream system;
+    system << "Game: " << utf8(game.filename().wstring()) << "\nGame version: " << file_version(game)
+           << "\nAdd-on version: " << file_version(addon) << '\n';
+    using RtlVersionFn = LONG(WINAPI*)(PRTL_OSVERSIONINFOW);
+    const auto rtl = reinterpret_cast<RtlVersionFn>(GetProcAddress(GetModuleHandleW(L"ntdll.dll"), "RtlGetVersion"));
+    RTL_OSVERSIONINFOW os{};
+    os.dwOSVersionInfoSize = sizeof(os);
+    if (rtl && rtl(&os) == 0)
+        system << "Windows: " << os.dwMajorVersion << '.' << os.dwMinorVersion << '.' << os.dwBuildNumber << '\n';
+    IDXGIFactory* factory{};
+    if (SUCCEEDED(CreateDXGIFactory(__uuidof(IDXGIFactory), reinterpret_cast<void**>(&factory)))) {
+        IDXGIAdapter* adapter{};
+        for (UINT i = 0; factory->EnumAdapters(i, &adapter) == S_OK; ++i) {
+            DXGI_ADAPTER_DESC desc{};
+            if (SUCCEEDED(adapter->GetDesc(&desc))) {
+                system << "Adapter: " << utf8(desc.Description) << " (vendor=" << desc.VendorId
+                    << ", device=" << desc.DeviceId << ", VRAM=" << desc.DedicatedVideoMemory << ")\n";
+                LARGE_INTEGER version{};
+                if (SUCCEEDED(adapter->CheckInterfaceSupport(__uuidof(IDXGIDevice), &version)))
+                    system << "Driver: " << HIWORD(version.HighPart) << '.' << LOWORD(version.HighPart)
+                        << '.' << HIWORD(version.LowPart) << '.' << LOWORD(version.LowPart) << '\n';
+            }
+            adapter->Release();
+        }
+        factory->Release();
+    }
+    for (const auto dll : {L"nvngx_dlss.dll", L"nvngx_dlssnr.dll", L"CheekyOpenXRLayer.dll", L"dxgi.dll", L"d3d11.dll"}) {
+        if (const auto module = GetModuleHandleW(dll))
+            system << utf8(dll) << ": " << file_version(module_path(module)) << '\n';
+    }
+    files.push_back({"system.txt", system.str()});
+    files.push_back({"README.txt", manifest.str()});
+    const auto partial = folder / L"report.partial";
+    const auto zip = folder / (std::wstring(name) + L".zip");
+    write_support_zip(partial, files);
+    fs::rename(partial, zip);
+    return zip;
+}
+
+bool open_target(const wchar_t* target, const wchar_t* args = nullptr) {
+    return reinterpret_cast<INT_PTR>(ShellExecuteW(nullptr, L"open", target, args, nullptr, SW_SHOWNORMAL)) > 32;
+}
+
+void show_zip() {
+    const auto args = L"/select,\"" + last_zip.wstring() + L"\"";
+    if (!open_target(L"explorer.exe", args.c_str())) status = "Could not open Explorer. ZIP path shown below.";
+}
+
+std::wstring issue_url() {
+    return std::wstring(issue_base) + L"&title=Bug%20report&report=" +
+        url_encode(utf8(last_zip.filename().wstring())) + L"&environment=" + url_encode(last_summary);
+}
+
+void open_issue() {
+    const auto url = issue_url();
+    if (!open_target(url.c_str())) status = "Could not open browser. Use Copy issue link and open it manually.";
+}
+}
+
+void draw_support_report(HMODULE addon) {
+    try {
+        if (pending.valid() && pending.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
+            last_zip = pending.get();
+            last_summary = pending_summary;
+            status = "Report prepared. Drag the selected ZIP into the GitHub issue, describe the problem, then submit.";
+            open_issue();
+            show_zip();
+        }
+        ImGui::SeparatorText("Report a problem");
+        ImGui::TextWrapped("Collect logs, settings and diagnostics into a ZIP. Review it before attaching; logs may contain personal paths. Nothing uploads automatically.");
+        ImGui::BeginDisabled(pending.valid());
+        const bool clicked = ImGui::Button("Report an issue...");
+        ImGui::EndDisabled();
+        if (clicked) {
+            const auto addon_file = module_path(addon);
+            const auto game_file = module_path(nullptr);
+            auto settings = settings_text(current_settings());
+            auto diagnostics = diagnostics_text();
+            pending_summary = std::string("Add-on: ") + CHEEKY_VERSION +
+                "\nGame: " + utf8(game_file.filename().wstring()) +
+                "\nDX11: " + diagnostic_state_name(diagnostic_snapshot(DiagnosticApi::d3d11).state) +
+                "\nDX12: " + diagnostic_state_name(diagnostic_snapshot(DiagnosticApi::d3d12).state);
+            pending = std::async(std::launch::async, create_report, addon_file, game_file,
+                                 std::move(settings), std::move(diagnostics));
+            status = "Preparing support ZIP...";
+        }
+        if (!status.empty()) ImGui::TextWrapped("%s", status.c_str());
+        if (!last_zip.empty()) {
+            ImGui::TextWrapped("%s", utf8(last_zip.wstring()).c_str());
+            if (ImGui::Button("Show ZIP")) show_zip();
+            ImGui::SameLine();
+            if (ImGui::Button("Open GitHub issue")) open_issue();
+            ImGui::SameLine();
+            if (ImGui::Button("Copy issue link")) ImGui::SetClipboardText(utf8(issue_url()).c_str());
+        }
+    } catch (const std::exception& error) {
+        status = std::string("Report failed: ") + error.what() + ". Click Report an issue to retry.";
+    }
+}
+
+void finish_support_report() noexcept {
+    if (pending.valid()) { try { pending.get(); } catch (...) {} }
+}
+}

--- a/src/support_report.cpp
+++ b/src/support_report.cpp
@@ -1,6 +1,7 @@
 #include "support_report.hpp"
 #include "support_zip.hpp"
 #include "support_summary.hpp"
+#include "support_prompts.hpp"
 #include "diagnostics.hpp"
 #include "dlss_nr.hpp"
 #include "gaze_foveation.hpp"
@@ -34,6 +35,7 @@ fs::path last_zip;
 std::string last_markdown;
 std::string status;
 std::string pending_summary, last_summary;
+SupportPrompts pending_prompts, last_prompts;
 
 std::wstring url_encode(const std::string& text) {
     constexpr wchar_t hex[] = L"0123456789ABCDEF";
@@ -408,7 +410,8 @@ void show_zip() {
 
 std::wstring issue_url() {
     auto url = std::wstring(issue_base) + L"&title=Bug%20report&report=" +
-        url_encode(utf8(last_zip.filename().wstring())) + L"&environment=" + url_encode(last_summary);
+        url_encode(utf8(last_zip.filename().wstring())) + L"&environment=" + url_encode(last_summary) +
+        L"&problem=" + url_encode(last_prompts.problem) + L"&steps=" + url_encode(last_prompts.steps);
     // Settings and diagnostics fit in a normal issue URL. Keep the potentially
     // huge log excerpts and capture manifest in the ZIP/copyable report only.
     const auto end = last_markdown.find("### Capture details and log availability");
@@ -436,6 +439,7 @@ void draw_support_report(HMODULE addon) {
             last_zip = std::move(report.zip);
             last_markdown = std::move(report.markdown);
             last_summary = pending_summary;
+            last_prompts = pending_prompts;
             status = "Diagnostics and settings are prefilled on GitHub. Review them, then drag the selected ZIP into Support ZIP.";
             open_issue();
             show_zip();
@@ -450,6 +454,13 @@ void draw_support_report(HMODULE addon) {
             const auto game_file = module_path(nullptr);
             auto settings = settings_text(current_settings());
             auto diagnostics = diagnostics_text();
+            const auto gaze = gaze_diagnostics();
+            const bool openxr_activity = gaze.layer_present && gaze.abi_compatible &&
+                ((gaze.status_flags & CHEEKY_GAZE_STATUS_SESSION_FOCUSED) != 0U ||
+                 std::any_of(gaze.views.begin(), gaze.views.end(),
+                     [](const auto& view) { return view.resource_mapped; }));
+            pending_prompts = support_prompts(utf8(game_file.filename().wstring()),
+                openxr_activity, gaze.runtime_name);
             pending_summary = std::string("Add-on: ") + CHEEKY_VERSION +
                 "\nGame: " + utf8(game_file.filename().wstring()) +
                 "\nDX11: " + diagnostic_state_name(diagnostic_snapshot(DiagnosticApi::d3d11).state) +

--- a/src/support_report.hpp
+++ b/src/support_report.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <Windows.h>
+
+namespace cheeky::foveated_dlss {
+void draw_support_report(HMODULE addon);
+// Called from AddonUninit, outside the loader lock, before unloading code.
+void finish_support_report() noexcept;
+}

--- a/src/support_summary.hpp
+++ b/src/support_summary.hpp
@@ -1,0 +1,161 @@
+#pragma once
+
+#include "cheeky_gaze_abi.h"
+#include <map>
+#include <set>
+#include <sstream>
+#include <string>
+
+namespace cheeky::foveated_dlss {
+// Summarize the captured text, never re-sample live state while formatting.
+inline std::string support_summary(const std::string& system,
+                                   const std::string& diagnostics,
+                                   const std::string& settings) {
+    using Fields = std::map<std::string, std::string>;
+    std::map<std::string, Fields> sections;
+    auto parse = [&](const std::string& text) {
+        std::istringstream in(text);
+        std::string line, section;
+        while (std::getline(in, line)) {
+            if (!line.empty() && line.back() == '\r') line.pop_back();
+            if (line.starts_with('[') && line.ends_with(']')) section = line.substr(1, line.size() - 2);
+            else if (const auto equals = line.find('='); equals != std::string::npos)
+                sections[section][line.substr(0, equals)] = line.substr(equals + 1);
+        }
+    };
+    parse(diagnostics); parse(settings);
+    const auto get = [&](const std::string& section, const std::string& key) {
+        const auto s = sections.find(section);
+        if (s == sections.end()) return std::string("unavailable");
+        const auto f = s->second.find(key);
+        return f == s->second.end() ? std::string("unavailable") : f->second;
+    };
+    const auto setting = [&](const char* key) { return get("CheekyFoveatedDLSS", key); };
+    const bool nr = setting("nr_enabled") == "true";
+    std::size_t longest{}, run{};
+    for (const auto* text : {&system, &diagnostics, &settings}) {
+        run = 0;
+        for (const char c : *text) {
+            run = c == '`' ? run + 1 : 0;
+            if (run > longest) longest = run;
+        }
+    }
+    const std::string fence(longest < 3 ? 3 : longest + 1, '`');
+    std::ostringstream out;
+    out << "### System\n\n" << fence << "text\n";
+    std::istringstream sys(system);
+    std::string line;
+    std::set<std::string> adapters;
+    bool keep_driver{};
+    while (std::getline(sys, line)) {
+        if (!line.empty() && line.back() == '\r') line.pop_back();
+        if (line.starts_with("Adapter:")) {
+            keep_driver = line.find("Microsoft Basic Render Driver") == std::string::npos && adapters.insert(line).second;
+            if (keep_driver) out << line << '\n';
+        } else if (line.starts_with("Driver:")) {
+            if (keep_driver) out << line << '\n';
+        } else if (const auto dll = line.find(".dll:"); dll != std::string::npos) {
+            const auto name = line.substr(0, dll);
+            if (name == "dxgi" || name == "d3d11") continue;
+            if (name == "nvngx_dlssnr" && !nr) continue;
+            if (name == "CheekyOpenXRLayer" && setting("center_mode") != "1" && setting("auto_stereo_alignment") != "true") continue;
+            if (name.starts_with("sl.") && line.find(": loaded") == std::string::npos) continue;
+            out << line.substr(0, line.find(';')) << '\n';
+        } else if (!line.empty() && !line.starts_with("Relevant runtime")) out << line << '\n';
+    }
+    if (adapters.empty()) out << "Hardware GPU: not identified; see system.txt in ZIP\n";
+    // Retain build identity without repeating the version/schema headers.
+    const auto build = diagnostics.find("Build:");
+    if (build != std::string::npos) out << diagnostics.substr(build, diagnostics.find('\n', build) - build) << '\n';
+    out << fence << "\n\n### Feature status\n\n";
+    for (const auto api : {"DX11", "DX12"}) {
+        const auto evaluations = get(api, "evaluate_calls");
+        out << "- " << api << ": " << (evaluations == "0" ? "no evaluations recorded" : get(api, "state_name")) << '\n';
+    }
+    out << "- DLSS-SR foveation: " << (setting("enabled") == "true" ? "enabled" : "disabled") << '\n'
+        << "- Peripheral DLAA: " << (setting("peripheral_dlaa_enabled") == "true" ? "enabled" : "disabled") << '\n'
+        << "- DLSS-NR: " << (nr ? get("DLSS-NR", "state") : "disabled") << "\n\n";
+    if (setting("center_mode") == "1" && get("OpenXR", "using_gaze") == "false")
+        out << "**Check:** OpenXR gaze is selected, but gaze was not being used at capture time. This snapshot alone does not establish why.\n\n";
+    if (setting("auto_stereo_alignment") == "true" && get("OpenXR", "alignment_source") == "0")
+        out << "**Check:** Automatic alignment is enabled, but the latest evaluated view reports manual fallback.\n\n";
+    out << "### Relevant diagnostics\n\n" << fence << "text\n";
+    auto row = [&](const std::string& section, const char* key, const char* label) {
+        out << label << ": " << get(section, key) << '\n';
+    };
+    auto timing = [&](const std::string& section, const char* key, const char* label) {
+        const auto value = get(section, key);
+        out << label << ": " << (value == "0" ? "not sampled / unavailable" : value + " ms") << '\n';
+    };
+    for (const auto api : {"DX11", "DX12"}) {
+        if (get(api, "evaluate_calls") == "0") continue;
+        out << '[' << api << "]\n";
+        row(api, "state_name", "State");
+        if (std::string(api) == "DX12") row(api, "d3d12_ngx_route", "NGX route");
+        else {
+            row(api, "execution_path", "Execution path");
+            row(api, "transport_status", "DX12 transport");
+        }
+        out << "Evaluations: " << get(api, "evaluate_calls") << "; active: " << get(api, "active_calls") << '\n';
+        row(api, "last_result", "Last NGX result");
+        if (get(api, "has_private_result") == "true") row(api, "last_private_result", "Last private NGX result");
+        out << "Input: " << get(api, "received_input_width") << 'x' << get(api, "received_input_height")
+            << "; output: " << get(api, "received_output_width") << 'x' << get(api, "received_output_height") << '\n'
+            << "Motion vectors: " << get(api, "motion_vector_width") << 'x' << get(api, "motion_vector_height")
+            << " (" << get(api, "motion_vector_space") << ")\n";
+        row(api, "input_crop", "Input crop (x,y,w,h)");
+        row(api, "output_crop", "Output crop (x,y,w,h)");
+        timing(api, "foveated_dlss_gpu_ms", "Foveated DLSS GPU");
+        if (setting("peripheral_dlaa_enabled") == "true") timing(api, "peripheral_dlaa_gpu_ms", "Peripheral DLAA GPU");
+        timing(api, "native_dlss_gpu_ms", "Native DLSS GPU");
+        if (nr) {
+            timing(api, "full_dlss_nr_gpu_ms", "Full DLSS-NR GPU");
+            timing(api, "foveated_dlss_nr_gpu_ms", "Foveated DLSS-NR GPU");
+        }
+        if (std::string(api) == "DX11" && setting("d3d11_use_d3d12_transport") == "true") timing(api, "transport_gpu_ms", "Transport GPU");
+        out << '\n';
+    }
+    out << "[OpenXR]\n";
+    row("OpenXR", "runtime_name", "Runtime");
+    row("OpenXR", "layer_present", "Layer loaded");
+    row("OpenXR", "abi_compatible", "Compatible ABI");
+    row("OpenXR", "using_gaze", "Using gaze");
+    const auto source_name = [](const std::string& source) {
+        return source == "0" ? "Manual fallback" : source == "1" ? "Streamline" : source == "2" ? "OpenXR" : "Unknown";
+    };
+    out << "Alignment source: " << source_name(get("OpenXR", "alignment_source")) << '\n';
+    row("OpenXR", "mapping_ambiguous", "Mapping ambiguous");
+    row("OpenXR", "sample_age_ms", "Sample age (ms)");
+    const auto flag_text = get("OpenXR", "status_flags");
+    if (flag_text != "unavailable") {
+        const auto flags = std::stoul(flag_text);
+        for (const auto& flag : {
+            std::pair{CHEEKY_GAZE_STATUS_LAYER_ACTIVE, "Layer active"},
+            std::pair{CHEEKY_GAZE_STATUS_EXTENSION_ENABLED, "Eye-tracking extension enabled"},
+            std::pair{CHEEKY_GAZE_STATUS_SYSTEM_SUPPORTED, "Eye tracking supported"},
+            std::pair{CHEEKY_GAZE_STATUS_SESSION_FOCUSED, "Session focused"},
+            std::pair{CHEEKY_GAZE_STATUS_ACTION_ACTIVE, "Gaze action active"},
+            std::pair{CHEEKY_GAZE_STATUS_GAZE_VALID, "Gaze valid"},
+            std::pair{CHEEKY_GAZE_STATUS_MAPPING_READY, "Mapping ready"},
+            std::pair{CHEEKY_GAZE_STATUS_UNSUPPORTED_VIEW_CONFIG, "Unsupported view configuration"},
+            std::pair{CHEEKY_GAZE_STATUS_AMBIGUOUS_RESOURCE, "Ambiguous resource"},
+            std::pair{CHEEKY_GAZE_STATUS_SIMULATED, "Simulated gaze"}})
+            out << flag.second << ": " << ((flags & flag.first) ? "yes" : "no") << '\n';
+    }
+    for (const auto eye : {"Eye 0", "Eye 1"}) {
+        out << eye << ": mapped=" << get(eye, "resource_mapped")
+            << "; packed stereo=" << get(eye, "packed_stereo_mapping")
+            << "; center=" << get(eye, "center_u") << ',' << get(eye, "center_v")
+            << "; alignment=" << source_name(get(eye, "alignment_source")) << '\n';
+    }
+    if (nr) {
+        out << "\n[DLSS-NR]\n";
+        for (const auto key : {"state", "route", "evaluation_calls", "failed_calls", "last_result", "region_width", "region_height", "working_width", "working_height"})
+            row("DLSS-NR", key, key);
+    }
+    out << fence << "\n\n<details>\n<summary>All current add-on settings</summary>\n\n" << fence << "ini\n"
+        << settings << '\n' << fence << "\n\n</details>\n\n"
+        << "Full diagnostic counters, resource identifiers and logs are retained in the attached support ZIP.\n\n";
+    return out.str();
+}
+}

--- a/src/support_zip.hpp
+++ b/src/support_zip.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace cheeky::foveated_dlss {
+struct SupportFile { std::string name, contents; };
+
+// Small, bounded ZIP32 archive using the standard STORE method (no dependency).
+// Callers supply ASCII flat filenames and at most 20 MiB of report data.
+inline void write_support_zip(const std::filesystem::path& path,
+                              const std::vector<SupportFile>& files) {
+    std::ofstream out(path, std::ios::binary);
+    out.exceptions(std::ios::failbit | std::ios::badbit);
+    auto u16 = [&](std::uint16_t n) {
+        out.put(static_cast<char>(n)); out.put(static_cast<char>(n >> 8));
+    };
+    auto u32 = [&](std::uint32_t n) {
+        u16(static_cast<std::uint16_t>(n)); u16(static_cast<std::uint16_t>(n >> 16));
+    };
+    struct Entry { std::uint32_t crc, size, offset; std::string name; };
+    std::vector<Entry> entries;
+    std::size_t total{};
+    for (const auto& file : files) {
+        total += file.contents.size();
+        if (total > 20U * 1024U * 1024U || files.size() > 100U ||
+            file.name.empty() || file.name.size() > 255U ||
+            file.name.find_first_of("/\\:") != std::string::npos)
+            throw std::runtime_error("Invalid support archive size or filename");
+        std::uint32_t crc = 0xffffffffU;
+        for (unsigned char c : file.contents) {
+            crc ^= c;
+            for (int bit = 0; bit != 8; ++bit)
+                crc = (crc >> 1) ^ (0xedb88320U & (0U - (crc & 1U)));
+        }
+        Entry e{~crc, static_cast<std::uint32_t>(file.contents.size()),
+                static_cast<std::uint32_t>(out.tellp()), file.name};
+        u32(0x04034b50); u16(20); u16(0); u16(0); u16(0); u16(0x21);
+        u32(e.crc); u32(e.size); u32(e.size);
+        u16(static_cast<std::uint16_t>(e.name.size())); u16(0);
+        out.write(e.name.data(), e.name.size());
+        out.write(file.contents.data(), file.contents.size());
+        entries.push_back(e);
+    }
+    const auto directory = static_cast<std::uint32_t>(out.tellp());
+    for (const auto& e : entries) {
+        u32(0x02014b50); u16(20); u16(20); u16(0); u16(0); u16(0); u16(0x21);
+        u32(e.crc); u32(e.size); u32(e.size);
+        u16(static_cast<std::uint16_t>(e.name.size()));
+        u16(0); u16(0); u16(0); u16(0); u32(0); u32(e.offset);
+        out.write(e.name.data(), e.name.size());
+    }
+    const auto size = static_cast<std::uint32_t>(out.tellp()) - directory;
+    u32(0x06054b50); u16(0); u16(0);
+    u16(static_cast<std::uint16_t>(entries.size()));
+    u16(static_cast<std::uint16_t>(entries.size()));
+    u32(size); u32(directory); u16(0);
+    out.close();
+}
+}

--- a/tests/gaze_tests.cpp
+++ b/tests/gaze_tests.cpp
@@ -1043,6 +1043,7 @@ void test_gaze_copy_routes() {
 }
 
 int run_d3d12_composite_tests();
+int run_support_summary_tests();
 
 int main(int argc, char** argv) {
     test_packed_alignment_coordinator();
@@ -1075,6 +1076,7 @@ int main(int argc, char** argv) {
     test_dlss_nr_reuses_live_sr_crop_center();
     test_dlss_nr_independent_size_shares_sr_center();
     test_openxr_layer_is_retained_while_snapshot_export_is_cached();
+    failures += run_support_summary_tests();
     if (failures != 0) {
         std::cerr << failures << " test(s) failed\n";
         return 1;

--- a/tests/support_summary_tests.cpp
+++ b/tests/support_summary_tests.cpp
@@ -1,4 +1,5 @@
 #include "support_summary.hpp"
+#include "support_prompts.hpp"
 #include <iostream>
 
 int run_support_summary_tests() {
@@ -27,5 +28,10 @@ int run_support_summary_tests() {
     enabled.replace(enabled.find("nr_enabled=false"), 16, "nr_enabled=true");
     const auto enabled_report = support_summary(system, diagnostics, enabled);
     check(enabled_report.find("[DLSS-NR]") != std::string::npos && enabled_report.find("nvngx_dlssnr.dll") != std::string::npos, "retain enabled NR details and dependency");
+    const auto prompts = cheeky::foveated_dlss::support_prompts("TestGame.exe", true, "Pimax OpenXR");
+    check(prompts.problem.find("TestGame.exe") != std::string::npos && prompts.steps.find("Launch TestGame.exe in VR mode") != std::string::npos, "prefill game and detected VR");
+    check(prompts.problem.find("**OpenXR runtime:** Pimax OpenXR") != std::string::npos && prompts.problem.find("**Headset:** Not detected") != std::string::npos, "do not mistake runtime for headset model");
+    const auto unknown = cheeky::foveated_dlss::support_prompts("TestGame.exe", false, "");
+    check(unknown.problem.find("confirm desktop or VR") != std::string::npos, "absence of OpenXR is not proof of desktop mode");
     return failures;
 }

--- a/tests/support_summary_tests.cpp
+++ b/tests/support_summary_tests.cpp
@@ -1,0 +1,31 @@
+#include "support_summary.hpp"
+#include <iostream>
+
+int run_support_summary_tests() {
+    using cheeky::foveated_dlss::support_summary;
+    const std::string system = "Game: Test.exe\nAdapter: Test GPU\nDriver: 1.2\nAdapter: Test GPU\nDriver: 1.2\nAdapter: Microsoft Basic Render Driver\nDriver: 0\nnvngx_dlss.dll: loaded, version 1; beside game=present\nnvngx_dlssnr.dll: loaded, version 2\ndxgi.dll: loaded\n";
+    const std::string diagnostics = "[DX11]\nevaluate_calls=0\n[DX12]\nevaluate_calls=100\nactive_calls=100\nstate_name=Active\nd3d12_ngx_route=Core runtime\nfoveated_dlss_gpu_ms=0\nruntime_loaded=true\nxr_resource=123456\n[OpenXR]\nusing_gaze=false\nalignment_source=0\nstatus_flags=119\n[DLSS-NR]\nstate=Active\nroute=Native\n";
+    const std::string settings = "[CheekyFoveatedDLSS]\nnr_enabled=false\nenabled=true\ncenter_mode=1\nauto_stereo_alignment=true\nwidth=0.22\n";
+    const auto report = support_summary(system, diagnostics, settings);
+    int failures{};
+    auto check = [&](bool condition, const char* message) {
+        if (!condition) { std::cerr << "Support summary: " << message << '\n'; ++failures; }
+    };
+    check(report.find("DX11: no evaluations recorded") != std::string::npos, "collapse inactive API");
+    check(report.find("[DX11]") == std::string::npos, "omit inactive detail");
+    check(report.find("[DX12]") != std::string::npos && report.find("Core runtime") != std::string::npos, "retain active route");
+    check(report.find("DLSS-NR: disabled") != std::string::npos && report.find("[DLSS-NR]") == std::string::npos, "collapse disabled NR");
+    check(report.find("nvngx_dlssnr.dll") == std::string::npos, "omit disabled dependency");
+    check(report.find("dxgi.dll") == std::string::npos && report.find("123456") == std::string::npos, "omit low-level noise");
+    check(report.find("Adapter: Test GPU") == report.rfind("Adapter: Test GPU"), "deduplicate GPU");
+    check(report.find("Microsoft Basic") == std::string::npos, "omit software adapter beside hardware");
+    check(report.find("not sampled / unavailable") != std::string::npos, "zero is not measured cost");
+    check(report.find("Session focused: no") != std::string::npos && report.find("Gaze valid: yes") != std::string::npos, "decode flags");
+    check(report.find("gaze was not being used") != std::string::npos && report.find("manual fallback") != std::string::npos, "highlight requested/observed mismatch");
+    check(report.find("<details>") != std::string::npos && report.find(settings) != std::string::npos, "retain every setting in details");
+    auto enabled = settings;
+    enabled.replace(enabled.find("nr_enabled=false"), 16, "nr_enabled=true");
+    const auto enabled_report = support_summary(system, diagnostics, enabled);
+    check(enabled_report.find("[DLSS-NR]") != std::string::npos && enabled_report.find("nvngx_dlssnr.dll") != std::string::npos, "retain enabled NR details and dependency");
+    return failures;
+}


### PR DESCRIPTION
Closes #17

## What changes

Adds **Report an issue...** to the ReShade add-on panel so users can report problems without manually locating logs or transcribing settings. The button captures the current state, prepares a support ZIP in the background, opens a prefilled GitHub issue, and selects the ZIP in Explorer for drag-and-drop attachment.

The issue shows system/runtime versions, active graphics-path diagnostics, readable OpenXR status, and all add-on settings in a collapsible section. Unused APIs and disabled features are summarized; requested gaze/alignment that differs from observed state is highlighted. Game and detected OpenXR activity prefill the editable description and reproduction prompts. Unknown mode/headset information is left for the user to confirm.

The ZIP retains the complete diagnostic dump, system inventory, settings, and available add-on/ReShade/crash logs. Logs are limited to their last 4 MiB, with missing/truncated files documented. A reviewable Markdown report is also saved. Nothing is uploaded or submitted automatically; users review the report, attach the ZIP, and submit. Oversized issue URLs use an explicit clipboard fallback.

Includes the GitHub issue form and points the production issue link at ClarkCheekyKent/CheekyFoveatedDLSS. The form becomes available once it reaches the default branch.

## Validation

- Release build and existing Cheeky test suite pass.
- Added regression coverage for active/inactive feature summaries, duplicate GPU filtering, decoded OpenXR flags, unavailable timing values, gaze/alignment discrepancies, full settings retention, and game/mode prompts.
- Exercised report collection with open, missing, oversized, empty, and binary log fixtures; verified ZIP extraction and CRCs with an independent reader.
- Tested the prefilled reporting flow in Assetto Corsa EVO against the fork's issue form before changing the destination to upstream. No upstream issue was submitted during testing.

## Notes

Reports are local until the user opens the populated GitHub link or attaches files. Logs are not automatically redacted and may contain personal paths or identifiers. Headset model detection is not currently exposed by the diagnostic interface, so the prompt asks the user to supply it.

